### PR TITLE
Fix memory calc and optimize sample buffer

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -83,7 +83,7 @@ void Roode::update() {
 #ifdef ESP32
     pct = (float) ESP.getFreeHeap() * 100.0f / (float) ESP.getHeapSize();
 #else
-    pct = (float) ESP.getFreeHeap() * 100.0f / (float) ESP.getHeapSize();
+    pct = (float) ESP.getFreeHeap() * 100.0f / 81920.0f;
 #endif
     ram_free_sensor->publish_state(pct);
   }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -83,16 +83,16 @@ void Roode::update() {
 #ifdef ESP32
     total = ESP.getHeapSize();
 #else
-    total = 81920;
+    total = ESP8266_HEAP_SIZE;
 #endif
     uint32_t used = total - ESP.getFreeHeap();
-    float pct = ((float)(total - used) * 100.0f) / (float) total;
+    float pct = ((float) (total - used) * 100.0f) / (float) total;
     ram_free_sensor->publish_state(pct);
   }
   if (flash_free_sensor != nullptr) {
     uint32_t total = ESP.getFlashChipSize();
     uint32_t used = ESP.getSketchSize();
-    float pct = ((float)(total - used) * 100.0f) / (float) total;
+    float pct = ((float) (total - used) * 100.0f) / (float) total;
     flash_free_sensor->publish_state(pct);
   }
 }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -174,7 +174,8 @@ class Roode : public PollingComponent {
   float loop_time_ms_{0};
   float cpu_usage_{0};
   float loop_time_accum_{0};
-  uint32_t busy_us_accum_{0};
+  float cpu_usage_accum_{0};
+  uint32_t last_loop_ts_{0};
   uint16_t diag_sample_count_{0};
   uint32_t diag_last_ts_{0};
   int number_attempts = 20;  // TO DO: make this configurable

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -27,6 +27,7 @@ namespace roode {
 static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
 static const char *const CALIBRATION = "Sensor Calibration";
+constexpr uint32_t ESP8266_HEAP_SIZE = 81920;
 
 /*
 Use the VL53L1X_SetTimingBudget function to set the TB in milliseconds. The TB

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -107,16 +107,15 @@ void Zone::reset_roi(uint8_t default_center) {
 
 void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
   ESP_LOGD(CALIBRATION, "Beginning. zoneId: %d", id);
-  std::vector<int> zone_distances;
-  zone_distances.reserve(number_attempts);
-  zone_distances.resize(number_attempts);
+  uint8_t count = number_attempts > CAL_THRESHOLD_SIZE ? CAL_THRESHOLD_SIZE : number_attempts;
+  std::array<int, CAL_THRESHOLD_SIZE> zone_distances{};
   int sum = 0;
-  for (int i = 0; i < number_attempts; i++) {
+  for (uint8_t i = 0; i < count; i++) {
     this->readDistance(distanceSensor);
     zone_distances[i] = this->getDistance();
     sum += zone_distances[i];
   }
-  threshold->idle = this->getOptimizedValues(zone_distances.data(), sum, number_attempts);
+  threshold->idle = this->getOptimizedValues(zone_distances.data(), sum, count);
 
   if (threshold->max_percentage.has_value()) {
     threshold->max = (threshold->idle * threshold->max_percentage.value()) / 100;

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -33,6 +33,7 @@ enum class FilterMode { MINIMUM, MEDIAN };
 
 constexpr uint8_t MAX_SAMPLE_SIZE = 16;
 constexpr uint8_t CAL_SAMPLE_SIZE = 50;
+constexpr uint8_t CAL_THRESHOLD_SIZE = 32;
 
 class Zone {
  public:

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -3,6 +3,7 @@
 
 #include "esphome/core/application.h"
 #include <array>
+#include <algorithm>
 #include "esphome/core/log.h"
 #include "esphome/core/optional.h"
 #include "../vl53l1x/vl53l1x.h"
@@ -31,6 +32,7 @@ struct Threshold {
 enum class FilterMode { MINIMUM, MEDIAN };
 
 constexpr uint8_t MAX_SAMPLE_SIZE = 16;
+constexpr uint8_t CAL_SAMPLE_SIZE = 50;
 
 class Zone {
  public:
@@ -55,6 +57,7 @@ class Zone {
     max_samples = max > MAX_SAMPLE_SIZE ? MAX_SAMPLE_SIZE : max;
     sample_index = 0;
     sample_count = 0;
+    std::fill(samples.begin(), samples.end(), 0);
   };
   void set_filter_mode(FilterMode mode) { filter_mode = mode; };
   void init_pref(uint32_t base_key);

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -2,7 +2,7 @@
 #include <math.h>
 
 #include "esphome/core/application.h"
-#include <vector>
+#include <array>
 #include "esphome/core/log.h"
 #include "esphome/core/optional.h"
 #include "../vl53l1x/vl53l1x.h"
@@ -30,6 +30,8 @@ struct Threshold {
 
 enum class FilterMode { MINIMUM, MEDIAN };
 
+constexpr uint8_t MAX_SAMPLE_SIZE = 16;
+
 class Zone {
  public:
   explicit Zone(uint8_t id) : id{id} {};
@@ -50,8 +52,9 @@ class Zone {
   ROI *roi_override = new ROI();
   Threshold *threshold = new Threshold();
   void set_max_samples(uint8_t max) {
-    max_samples = max;
-    samples.reserve(max);
+    max_samples = max > MAX_SAMPLE_SIZE ? MAX_SAMPLE_SIZE : max;
+    sample_index = 0;
+    sample_count = 0;
   };
   void set_filter_mode(FilterMode mode) { filter_mode = mode; };
   void init_pref(uint32_t base_key);
@@ -67,8 +70,10 @@ class Zone {
   VL53L1_Error sensor_status = VL53L1_ERROR_NONE;
   uint16_t last_distance;
   uint16_t min_distance;
-  std::vector<uint16_t> samples;
-  uint8_t max_samples;
+  std::array<uint16_t, MAX_SAMPLE_SIZE> samples{};
+  uint8_t max_samples{1};
+  uint8_t sample_index{0};
+  uint8_t sample_count{0};
   FilterMode filter_mode{FilterMode::MINIMUM};
   ESPPreferenceObject pref_;
   struct CalibrationData {


### PR DESCRIPTION
## Summary
- use fixed-size ring buffer for sample filtering
- fall back to known heap size on ESP8266

## Testing
- `esphome version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687275cd2e848330bf19f556070a594b