### PR TITLE
Implement PRD features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - If a pin test fails at boot the feature is automatically disabled so the sensor continues operating
 - Xshut and interrupt pins use internal pull-ups so no extra resistors are needed
 - Optional sensors report loop time, CPU usage, RAM and flash usage percentages
+- Fail-safe recalibration restores thresholds if a zone stays active
+- Calibration data can persist in flash across reboots
+- Dual-core tasking keeps distance polling responsive on ESP32
+- Median/percentile filtering smooths jitter with a configurable window
+- State machine timeouts reset the FSM if a transition stalls
+- Optional CPU optimizations kick in automatically above 90% usage
 
 ## Hardware Recommendation
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ roode:
     # min: 50mm
     # max: 234cm
 
+  # Persist calibration data so thresholds survive restarts
+  calibration_persistence: true
+
+  # Jitter reduction options
+  filter_mode: median
+  filter_window: 5
+
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Dual-core tasking keeps distance polling responsive on ESP32
 - Median/percentile filtering smooths jitter with a configurable window
 - State machine timeouts reset the FSM if a transition stalls
-- Optional CPU optimizations kick in automatically above 90% usage
+- Optional CPU optimizations kick in automatically above 90% usage and revert once load drops
 
 ## Hardware Recommendation
 

--- a/README.md
+++ b/README.md
@@ -230,18 +230,30 @@ binary_sensor:
 sensor:
   - platform: roode
     id: hallway
-    distance_sensor:
-      name: $friendly_name distance
+    distance_entry:
+      name: $friendly_name distance zone 0
       filters:
         - delta: 100.0
-    threshold_entry:
-      name: $friendly_name Zone 0
-    threshold_exit:
-      name: $friendly_name Zone 1
-    roi_height:
-      name: $friendly_name ROI height
-    roi_width:
-      name: $friendly_name ROI width
+    distance_exit:
+      name: $friendly_name distance zone 1
+      filters:
+        - delta: 100.0
+    max_threshold_entry:
+      name: $friendly_name max zone 0
+    max_threshold_exit:
+      name: $friendly_name max zone 1
+    min_threshold_entry:
+      name: $friendly_name min zone 0
+    min_threshold_exit:
+      name: $friendly_name min zone 1
+    roi_height_entry:
+      name: $friendly_name ROI height zone 0
+    roi_width_entry:
+      name: $friendly_name ROI width zone 0
+    roi_height_exit:
+      name: $friendly_name ROI height zone 1
+    roi_width_exit:
+      name: $friendly_name ROI width zone 1
     loop_time:
       name: $friendly_name loop time
     cpu_usage:

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -33,6 +33,8 @@ CONF_ZONES = "zones"
 CONF_CALIBRATION_PERSISTENCE = "calibration_persistence"
 CONF_FILTER_MODE = "filter_mode"
 CONF_FILTER_WINDOW = "filter_window"
+CONF_LOG_FALLBACK = "log_fallback_events"
+CONF_FORCE_SINGLE_CORE = "force_single_core"
 
 FilterMode = roode_ns.enum("FilterMode")
 FILTER_MODES = {
@@ -87,6 +89,8 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_CALIBRATION_PERSISTENCE, default=False): cv.boolean,
         cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
         cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
+        cv.Optional(CONF_LOG_FALLBACK, default=False): cv.boolean,
+        cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
                 cv.Optional(CONF_INVERT, default=False): cv.boolean,
@@ -110,6 +114,8 @@ async def to_code(config: Dict):
     cg.add(roode.set_calibration_persistence(config[CONF_CALIBRATION_PERSISTENCE]))
     cg.add(roode.set_filter_mode(config[CONF_FILTER_MODE]))
     cg.add(roode.set_filter_window(config[CONF_FILTER_WINDOW]))
+    cg.add(roode.set_log_fallback_events(config[CONF_LOG_FALLBACK]))
+    cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
     cg.add(roode.set_invert_direction(config[CONF_ZONES][CONF_INVERT]))
     setup_zone(CONF_ENTRY_ZONE, config, roode)
     setup_zone(CONF_EXIT_ZONE, config, roode)

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -30,6 +30,16 @@ CONF_MIN = "min"
 CONF_ROI = "roi"
 CONF_SAMPLING = "sampling"
 CONF_ZONES = "zones"
+CONF_CALIBRATION_PERSISTENCE = "calibration_persistence"
+CONF_FILTER_MODE = "filter_mode"
+CONF_FILTER_WINDOW = "filter_window"
+
+FilterMode = roode_ns.enum("FilterMode")
+FILTER_MODES = {
+    "min": FilterMode.FILTER_MIN,
+    "median": FilterMode.FILTER_MEDIAN,
+    "percentile10": FilterMode.FILTER_PERCENTILE10,
+}
 
 Orientation = roode_ns.enum("Orientation")
 ORIENTATION_VALUES = {
@@ -74,6 +84,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_SAMPLING, default=2): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_ROI, default={}): ROI_SCHEMA,
         cv.Optional(CONF_DETECTION_THRESHOLDS, default={}): THRESHOLDS_SCHEMA,
+        cv.Optional(CONF_CALIBRATION_PERSISTENCE, default=False): cv.boolean,
+        cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
+        cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
                 cv.Optional(CONF_INVERT, default=False): cv.boolean,
@@ -94,6 +107,9 @@ async def to_code(config: Dict):
 
     cg.add(roode.set_orientation(config[CONF_ORIENTATION]))
     cg.add(roode.set_sampling_size(config[CONF_SAMPLING]))
+    cg.add(roode.set_calibration_persistence(config[CONF_CALIBRATION_PERSISTENCE]))
+    cg.add(roode.set_filter_mode(config[CONF_FILTER_MODE]))
+    cg.add(roode.set_filter_window(config[CONF_FILTER_WINDOW]))
     cg.add(roode.set_invert_direction(config[CONF_ZONES][CONF_INVERT]))
     setup_zone(CONF_ENTRY_ZONE, config, roode)
     setup_zone(CONF_EXIT_ZONE, config, roode)

--- a/components/roode/binary_sensor.py
+++ b/components/roode/binary_sensor.py
@@ -12,12 +12,20 @@ from . import Roode, CONF_ROODE_ID
 DEPENDENCIES = ["roode"]
 
 CONF_PRESENCE = "presence_sensor"
-TYPES = [CONF_PRESENCE]
+CONF_XSHUT_STATE = "sensor_xshut_state"
+TYPES = [CONF_PRESENCE, CONF_XSHUT_STATE]
 
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
         cv.Optional(CONF_PRESENCE): binary_sensor.binary_sensor_schema(
+            binary_sensor.BinarySensor
+        ).extend(
+            {
+                cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
+            }
+        ),
+        cv.Optional(CONF_XSHUT_STATE): binary_sensor.binary_sensor_schema(
             binary_sensor.BinarySensor
         ).extend(
             {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -167,6 +167,9 @@ void Roode::path_tracking(Zone *zone) {
     ESP_LOGW(TAG, "fsm_timeout_reset");
   }
 
+  ESP_LOGV(TAG, "Zone %d distance %u (min=%u max=%u)", zone->id, zone->getMinDistance(),
+           zone->threshold->min, zone->threshold->max);
+
   // PathTrack algorithm
   if (zone->getMinDistance() < zone->threshold->max && zone->getMinDistance() > zone->threshold->min) {
     // Someone is in the sensing area
@@ -358,7 +361,7 @@ void Roode::reset_cpu_optimizations(float cpu) {
 
 void Roode::update_metrics() {
   uint32_t now = millis();
-  if (now - loop_window_start_ < 30000)
+  if (now - loop_window_start_ < 10000)
     return;
   float cpu = 0.0f;
   if (loop_count_ > 0) {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -308,6 +308,12 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   z->reset_roi(zone_id == 0 ? (orientation_ == Parallel ? 167 : 195)
                              : (orientation_ == Parallel ? 231 : 60));
   z->calibrateThreshold(distanceSensor, 50);
+  // Recalculate ROI sizes so thresholds remain consistent
+  entry->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
+  exit->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
+  auto *mode = determine_ranging_mode(entry->threshold->idle, exit->threshold->idle);
+  distanceSensor->set_ranging_mode(mode);
+
   calibration_data_[zone_id].baseline_mm = z->threshold->idle;
   calibration_data_[zone_id].threshold_min_mm = z->threshold->min;
   calibration_data_[zone_id].threshold_max_mm = z->threshold->max;

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -29,6 +29,13 @@ void Roode::setup() {
     return;
   }
 
+  // Initialize filtering options before calibrating so threshold sampling uses
+  // the configured window and mode
+  entry->set_filter_window(filter_window_);
+  entry->set_filter_mode(filter_mode_);
+  exit->set_filter_window(filter_window_);
+  exit->set_filter_mode(filter_mode_);
+
   if (calibration_persistence_) {
     calibration_prefs_[0] = global_preferences->make_preference<CalibrationPrefs>(0xA0);
     calibration_prefs_[1] = global_preferences->make_preference<CalibrationPrefs>(0xA1);
@@ -78,10 +85,6 @@ void Roode::setup() {
   loop_window_start_ = millis();
   loop_time_sum_ = 0;
   loop_count_ = 0;
-  entry->set_filter_window(filter_window_);
-  entry->set_filter_mode(filter_mode_);
-  exit->set_filter_window(filter_window_);
-  exit->set_filter_mode(filter_mode_);
 }
 
 void Roode::update() {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -349,6 +349,11 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   if (calibration_persistence_) {
     calibration_prefs_[zone_id].save(&calibration_data_[zone_id]);
   }
+
+  // Publish the updated calibration data so Home Assistant sees the new
+  // thresholds and ROI values immediately after a fail-safe recalibration
+  publish_sensor_configuration(entry, exit, true);
+  publish_sensor_configuration(entry, exit, false);
 }
 
 void Roode::apply_cpu_optimizations(float cpu) {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -66,7 +66,7 @@ void Roode::setup() {
       exit->reset_roi(orientation_ == Parallel ? 231 : 60);
       entry->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
       exit->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
-      auto *mode = determine_raning_mode(entry->threshold->idle, exit->threshold->idle);
+      auto *mode = determine_ranging_mode(entry->threshold->idle, exit->threshold->idle);
       distanceSensor->set_ranging_mode(mode);
       publish_sensor_configuration(entry, exit, true);
       publish_sensor_configuration(entry, exit, false);
@@ -350,7 +350,7 @@ void Roode::apply_cpu_optimizations(float cpu) {
   cpu_optimizations_active_ = true;
 }
 
-const RangingMode *Roode::determine_raning_mode(uint16_t average_entry_zone_distance,
+const RangingMode *Roode::determine_ranging_mode(uint16_t average_entry_zone_distance,
                                                 uint16_t average_exit_zone_distance) {
   uint16_t min = average_entry_zone_distance < average_exit_zone_distance ? average_entry_zone_distance
                                                                           : average_exit_zone_distance;
@@ -406,7 +406,7 @@ void Roode::calibrateDistance() {
   if (distanceSensor->get_ranging_mode_override().has_value()) {
     return;
   }
-  auto *mode = determine_raning_mode(entry->threshold->idle, exit->threshold->idle);
+  auto *mode = determine_ranging_mode(entry->threshold->idle, exit->threshold->idle);
   if (mode != initial) {
     distanceSensor->set_ranging_mode(mode);
   }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -85,6 +85,17 @@ void Roode::setup() {
   loop_window_start_ = millis();
   loop_time_sum_ = 0;
   loop_count_ = 0;
+  if (status_sensor != nullptr)
+    status_sensor->publish_state(sensor_status);
+
+  if (loop_time_sensor != nullptr)
+    loop_time_sensor->publish_state(0);
+  if (cpu_usage_sensor != nullptr)
+    cpu_usage_sensor->publish_state(0);
+  if (ram_free_sensor != nullptr)
+    ram_free_sensor->publish_state(0);
+  if (flash_free_sensor != nullptr)
+    flash_free_sensor->publish_state(0);
 }
 
 void Roode::update() {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <math.h>
+#include <string>
+#include "Arduino.h"
 
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
@@ -23,7 +25,6 @@ namespace roode {
 static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
 static const char *const CALIBRATION = "Sensor Calibration";
-
 
 /*
 Use the VL53L1X_SetTimingBudget function to set the TB in milliseconds. The TB
@@ -56,6 +57,7 @@ static int time_budget_in_ms_max = 200;  // max range: 4m
 
 class Roode : public PollingComponent {
  public:
+  Roode() { instance_ = this; }
   void setup() override;
   void update() override;
   void loop() override;
@@ -104,6 +106,13 @@ class Roode : public PollingComponent {
   void set_entry_exit_event_text_sensor(text_sensor::TextSensor *entry_exit_event_sensor_) {
     entry_exit_event_sensor = entry_exit_event_sensor_;
   }
+  void set_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
+  void set_sensor_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
+  void set_interrupt_status_sensor(sensor::Sensor *sens) { interrupt_status_sensor = sens; }
+  void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }
+  void set_manual_adjustment_sensor(sensor::Sensor *sens) { manual_adjustment_sensor = sens; }
+  void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
+  void set_force_single_core(bool val) { force_single_core_ = val; }
   void set_calibration_persistence(bool val) { calibration_persistence_ = val; }
   void set_filter_mode(FilterMode mode) {
     filter_mode_ = mode;
@@ -119,11 +128,14 @@ class Roode : public PollingComponent {
   }
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
+  void set_entry_threshold_percentages(uint8_t min, uint8_t max) { entry->set_threshold_percentages(min, max); }
+  void set_exit_threshold_percentages(uint8_t min, uint8_t max) { exit->set_threshold_percentages(min, max); }
   void apply_cpu_optimizations(float cpu);
   void reset_cpu_optimizations(float cpu);
   void update_metrics();
   Zone *entry = new Zone(0);
   Zone *exit = new Zone(1);
+  static void log_event(const std::string &msg);
 
  protected:
   TofSensor *distanceSensor;
@@ -145,8 +157,12 @@ class Roode : public PollingComponent {
   sensor::Sensor *ram_free_sensor{nullptr};
   sensor::Sensor *flash_free_sensor{nullptr};
   binary_sensor::BinarySensor *presence_sensor{nullptr};
+  binary_sensor::BinarySensor *xshut_state_binary_sensor{nullptr};
   text_sensor::TextSensor *version_sensor{nullptr};
   text_sensor::TextSensor *entry_exit_event_sensor{nullptr};
+  text_sensor::TextSensor *enabled_features_sensor{nullptr};
+  sensor::Sensor *manual_adjustment_sensor{nullptr};
+  sensor::Sensor *interrupt_status_sensor{nullptr};
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;
@@ -167,6 +183,14 @@ class Roode : public PollingComponent {
   bool cpu_optimizations_active_{false};
   uint16_t polling_interval_ms_{10};
 
+  static bool log_fallback_events_;
+  static Roode *instance_;
+  int manual_adjustment_count_{0};
+  float expected_counter_{0};
+  bool force_single_core_{false};
+  TaskHandle_t sensor_task_handle_{nullptr};
+  uint8_t multicore_retry_count_{0};
+
   enum FSMState { STATE_IDLE, STATE_ENTRY_ACTIVE, STATE_BOTH_ACTIVE };
   FSMState state_{STATE_IDLE};
   uint32_t state_started_ts{0};
@@ -180,6 +204,7 @@ class Roode : public PollingComponent {
   bool handle_sensor_status();
   void calibrateDistance();
   void calibrate_zones();
+  void publish_feature_list();
   const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
   void publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax);
   void updateCounter(int delta);
@@ -200,4 +225,3 @@ class Roode : public PollingComponent {
 
 }  // namespace roode
 }  // namespace esphome
-

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -107,17 +107,20 @@ class Roode : public PollingComponent {
   void set_calibration_persistence(bool val) { calibration_persistence_ = val; }
   void set_filter_mode(FilterMode mode) {
     filter_mode_ = mode;
+    default_filter_mode_ = mode;
     entry->set_filter_mode(mode);
     exit->set_filter_mode(mode);
   }
   void set_filter_window(uint8_t window) {
     filter_window_ = window;
+    default_filter_window_ = window;
     entry->set_filter_window(window);
     exit->set_filter_window(window);
   }
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
   void apply_cpu_optimizations(float cpu);
+  void reset_cpu_optimizations(float cpu);
   void update_metrics();
   Zone *entry = new Zone(0);
   Zone *exit = new Zone(1);
@@ -158,6 +161,8 @@ class Roode : public PollingComponent {
 
   FilterMode filter_mode_{FILTER_MIN};
   uint8_t filter_window_{5};
+  FilterMode default_filter_mode_{FILTER_MIN};
+  uint8_t default_filter_window_{5};
 
   bool cpu_optimizations_active_{false};
   uint16_t polling_interval_ms_{10};

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -118,6 +118,7 @@ class Roode : public PollingComponent {
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
   void apply_cpu_optimizations(float cpu);
+  void update_metrics();
   Zone *entry = new Zone(0);
   Zone *exit = new Zone(1);
 

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -174,7 +174,7 @@ class Roode : public PollingComponent {
   bool handle_sensor_status();
   void calibrateDistance();
   void calibrate_zones();
-  const RangingMode *determine_raning_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
+  const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
   void publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax);
   void updateCounter(int delta);
   Orientation orientation_{Parallel};

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -124,14 +124,14 @@ class Roode : public PollingComponent {
  protected:
   TofSensor *distanceSensor;
   Zone *current_zone = entry;
-  sensor::Sensor *distance_entry;
-  sensor::Sensor *distance_exit;
-  number::Number *people_counter;
-  sensor::Sensor *max_threshold_entry_sensor;
-  sensor::Sensor *max_threshold_exit_sensor;
-  sensor::Sensor *min_threshold_entry_sensor;
-  sensor::Sensor *min_threshold_exit_sensor;
-  sensor::Sensor *exit_roi_height_sensor;
+  sensor::Sensor *distance_entry{nullptr};
+  sensor::Sensor *distance_exit{nullptr};
+  number::Number *people_counter{nullptr};
+  sensor::Sensor *max_threshold_entry_sensor{nullptr};
+  sensor::Sensor *max_threshold_exit_sensor{nullptr};
+  sensor::Sensor *min_threshold_entry_sensor{nullptr};
+  sensor::Sensor *min_threshold_exit_sensor{nullptr};
+  sensor::Sensor *exit_roi_height_sensor{nullptr};
   sensor::Sensor *exit_roi_width_sensor{nullptr};
   sensor::Sensor *entry_roi_height_sensor{nullptr};
   sensor::Sensor *entry_roi_width_sensor{nullptr};

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -28,6 +28,8 @@ CONF_LOOP_TIME = "loop_time"
 CONF_CPU_USAGE = "cpu_usage"
 CONF_RAM_FREE = "ram_free"
 CONF_FLASH_FREE = "flash_free"
+CONF_MANUAL_ADJUST = "manual_adjustment_count"
+CONF_INTERRUPT_STATUS = "interrupt_status"
 
 CONFIG_SCHEMA = sensor.sensor_schema().extend(
     {
@@ -134,6 +136,16 @@ CONFIG_SCHEMA = sensor.sensor_schema().extend(
             state_class=STATE_CLASS_MEASUREMENT,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
+        cv.Optional(CONF_INTERRUPT_STATUS): sensor.sensor_schema(
+            icon="mdi:lightning-bolt",
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_MANUAL_ADJUST): sensor.sensor_schema(
+            icon="mdi:counter",
+            accuracy_decimals=0,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
     }
 )
@@ -186,3 +198,9 @@ async def to_code(config):
     if CONF_FLASH_FREE in config:
         count = await sensor.new_sensor(config[CONF_FLASH_FREE])
         cg.add(var.set_flash_free_sensor(count))
+    if CONF_INTERRUPT_STATUS in config:
+        count = await sensor.new_sensor(config[CONF_INTERRUPT_STATUS])
+        cg.add(var.set_interrupt_status_sensor(count))
+    if CONF_MANUAL_ADJUST in config:
+        count = await sensor.new_sensor(config[CONF_MANUAL_ADJUST])
+        cg.add(var.set_manual_adjustment_sensor(count))

--- a/components/roode/text_sensor.py
+++ b/components/roode/text_sensor.py
@@ -14,8 +14,9 @@ DEPENDENCIES = ["roode"]
 VERSION = "version"
 ENTRY_EXIT_EVENT = "entry_exit_event"
 STATUS = "sensor_status"
+FEATURES = "enabled_features"
 
-TYPES = [VERSION, ENTRY_EXIT_EVENT, STATUS]
+TYPES = [VERSION, ENTRY_EXIT_EVENT, STATUS, FEATURES]
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -32,6 +33,15 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(ENTRY_EXIT_EVENT): text_sensor.text_sensor_schema().extend(
             {
                 cv.Optional(CONF_ICON, default="mdi:sign-direction"): cv.icon,
+                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                cv.Optional(
+                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+                ): cv.entity_category,
+            }
+        ),
+        cv.Optional(FEATURES): text_sensor.text_sensor_schema().extend(
+            {
+                cv.Optional(CONF_ICON, default="mdi:cog" ): cv.icon,
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
                 cv.Optional(
                     CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -92,8 +92,12 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
   } else {
     int avg = sum / zone_distances.size();
     threshold->idle = avg;
-    threshold->max = avg * 0.80;
-    threshold->min = avg * 0.15;
+    uint8_t max_pct = threshold->max_percentage.value_or(80);
+    uint8_t min_pct = threshold->min_percentage.value_or(15);
+    threshold->max_percentage = max_pct;
+    threshold->min_percentage = min_pct;
+    threshold->max = (avg * max_pct) / 100;
+    threshold->min = (avg * min_pct) / 100;
   }
 
   ESP_LOGI(CALIBRATION, "Calibrated threshold for zone. zoneId: %d, idle: %d, min: %d (%d%%), max: %d (%d%%)", id,
@@ -149,6 +153,14 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
 
 uint16_t Zone::getDistance() const { return this->last_distance; }
 uint16_t Zone::getMinDistance() const { return this->min_distance; }
+
+void Zone::set_threshold_percentages(uint8_t min_percent, uint8_t max_percent) {
+  threshold->min_percentage = min_percent;
+  threshold->max_percentage = max_percent;
+  if (threshold->idle > 0) {
+    threshold->min = (threshold->idle * min_percent) / 100;
+    threshold->max = (threshold->idle * max_percent) / 100;
+  }
+}
 }  // namespace roode
 }  // namespace esphome
-

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -147,24 +147,6 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
            roi->height, roi->center);
 }
 
-int Zone::getOptimizedValues(const std::vector<int> &values, int sum) const {
-  int size = values.size();
-  int sum_squared = 0;
-  int variance = 0;
-  int sd = 0;
-  int avg = sum / size;
-
-  for (int i = 0; i < size; i++) {
-    sum_squared = sum_squared + (values[i] * values[i]);
-    App.feed_wdt();
-  }
-  variance = sum_squared / size - (avg * avg);
-  sd = sqrt(variance);
-  ESP_LOGD(CALIBRATION, "Zone AVG: %d", avg);
-  ESP_LOGD(CALIBRATION, "Zone SD: %d", sd);
-  return avg - sd;
-}
-
 uint16_t Zone::getDistance() const { return this->last_distance; }
 uint16_t Zone::getMinDistance() const { return this->min_distance; }
 }  // namespace roode

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -39,6 +39,7 @@ class Zone {
   void reset_roi(uint8_t default_center);
   void calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
+  void set_threshold_percentages(uint8_t min_percent, uint8_t max_percent);
   const uint8_t id;
   uint16_t getDistance() const;
   uint16_t getMinDistance() const;
@@ -68,4 +69,3 @@ class Zone {
 };
 }  // namespace roode
 }  // namespace esphome
-

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -50,6 +50,7 @@ class Zone {
     max_samples = std::min<uint8_t>(window, MAX_BUFFER_SIZE);
     sample_idx_ = 0;
     sample_count_ = 0;
+    samples.fill(0);
   }
   void set_max_samples(uint8_t max) { set_filter_window(max); };
 

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -54,7 +54,6 @@ class Zone {
   void set_max_samples(uint8_t max) { set_filter_window(max); };
 
  protected:
-  int getOptimizedValues(const std::vector<int> &values, int sum) const;
   VL53L1_Error last_sensor_status = VL53L1_ERROR_NONE;
   VL53L1_Error sensor_status = VL53L1_ERROR_NONE;
   uint16_t last_distance{0};

--- a/components/vl53l1x/__init__.py
+++ b/components/vl53l1x/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_I2C,
     CONF_I2C_ID,
     CONF_INTERRUPT,
+    CONF_ADDRESS,
     CONF_OFFSET,
     CONF_PINS,
     CONF_TIMEOUT,
@@ -20,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 
 DEPENDENCIES = ["i2c"]
 AUTO_LOAD = ["i2c"]
-MULTI_CONF = False  # TODO enable when we support multiple addresses
+MULTI_CONF = True
 
 vl53l1x_ns = cg.esphome_ns.namespace("vl53l1x")
 VL53L1X = vl53l1x_ns.class_("VL53L1X", cg.Component)
@@ -30,6 +31,7 @@ CONF_CALIBRATION = "calibration"
 CONF_RANGING_MODE = "ranging"
 CONF_XSHUT = "xshut"
 CONF_XTALK = "crosstalk"
+CONF_SENSOR_ID = "sensor_id"
 
 Ranging = vl53l1x_ns.namespace("Ranging")
 RANGING_MODES = {
@@ -77,6 +79,7 @@ CONFIG_SCHEMA = (
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(VL53L1X),
+            cv.Optional(CONF_SENSOR_ID, default=1): cv.int_range(min=1, max=16),
             cv.Optional(
                 CONF_TIMEOUT, default="2s"
             ): cv.positive_time_period_milliseconds,
@@ -113,6 +116,8 @@ async def to_code(config: Dict):
     vl53l1x = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(vl53l1x, config)
     await i2c.register_i2c_device(vl53l1x, config)
+    cg.add(vl53l1x.set_sensor_id(config[CONF_SENSOR_ID]))
+    cg.add(vl53l1x.set_desired_address(config[CONF_ADDRESS]))
 
     # If i2c frequency has not been explicitly set, then increase it to our recommended
     i2c_id = config[CONF_I2C_ID]

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -1,12 +1,19 @@
 #include "vl53l1x.h"
+#include "../roode/roode.h"
+#include <cstdio>
 
 namespace esphome {
 namespace vl53l1x {
+
+std::vector<VL53L1X *> VL53L1X::sensors{};
 
 VL53L1X::~VL53L1X() {
   if (this->xshut_pin.has_value()) {
     this->xshut_pin.value()->digital_write(false);
     ESP_LOGD(TAG, "XShut pin set LOW - powering down sensor");
+    roode::Roode::log_event("xshut_sensor_" + std::to_string(sensor_id_) + "_off");
+    roode::Roode::log_event("xshut_toggled_off");
+    roode::Roode::log_event("xshut_toggled");
   }
   this->sensor.StopRanging();
 }
@@ -30,12 +37,25 @@ void VL53L1X::dump_config() {
 void VL53L1X::setup() {
   ESP_LOGD(TAG, "Beginning setup");
 
+  sensors.push_back(this);
+  for (auto *s : sensors) {
+    if (s != this && s->xshut_pin.has_value()) {
+      s->xshut_pin.value()->digital_write(false);
+      roode::Roode::log_event("xshut_sensor_" + std::to_string(s->sensor_id_) + "_off");
+      roode::Roode::log_event("xshut_toggled_off");
+      roode::Roode::log_event("xshut_toggled");
+    }
+  }
+
   if (this->xshut_pin.has_value()) {
     this->xshut_pin.value()->pin_mode(gpio::FLAG_OUTPUT | gpio::FLAG_PULLUP);
     this->xshut_pin.value()->setup();
     ESP_LOGD(TAG, "XShut pin configured");
     this->xshut_pin.value()->digital_write(true);
     ESP_LOGD(TAG, "XShut pin set HIGH - sensor powered on");
+    roode::Roode::log_event("xshut_sensor_" + std::to_string(sensor_id_) + "_on");
+    roode::Roode::log_event("xshut_toggled_on");
+    roode::Roode::log_event("xshut_toggled");
     delay(2);
   }
 
@@ -45,13 +65,22 @@ void VL53L1X::setup() {
     ESP_LOGD(TAG, "Interrupt pin configured");
   }
 
-  // TODO use xshut_pin, if given, to change address
   auto status = this->init();
   if (status != VL53L1_ERROR_NONE) {
     this->mark_failed();
     return;
   }
   ESP_LOGD(TAG, "Device initialized");
+  if (desired_address_ != 0x29) {
+    status = this->sensor.SetI2CAddress(desired_address_ << 1);
+    if (status == VL53L1_ERROR_NONE) {
+      char buf[5];
+      snprintf(buf, sizeof(buf), "%02X", desired_address_);
+      roode::Roode::log_event("sensor_" + std::to_string(sensor_id_) + "_addr = 0x" + std::string(buf));
+    } else {
+      ESP_LOGE(TAG, "Failed to change address. Error: %d", status);
+    }
+  }
 
   if (this->offset.has_value()) {
     ESP_LOGI(TAG, "Setting offset calibration to %d", this->offset.value());
@@ -76,6 +105,16 @@ void VL53L1X::setup() {
   if (!this->check_features()) {
     ESP_LOGE(TAG, "Feature check failed. Sensor disabled");
     return;
+  }
+
+  for (auto *s : sensors) {
+    if (s != this && s->xshut_pin.has_value()) {
+      s->xshut_pin.value()->digital_write(true);
+      roode::Roode::log_event("xshut_sensor_" + std::to_string(s->sensor_id_) + "_on");
+      roode::Roode::log_event("xshut_toggled_on");
+      roode::Roode::log_event("xshut_toggled");
+      delay(2);
+    }
   }
 
   ESP_LOGI(TAG, "Setup complete");
@@ -202,24 +241,70 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
     last_roi = roi;
   }
 
+  // Decide whether we can use the interrupt pin for this reading
+  uint8_t dataReady = false;
+  bool use_int = is_interrupt_enabled();
+  if (!use_int && this->interrupt_pin.has_value() &&
+      (millis() - last_interrupt_retry_ >= 1800000UL)) {
+    if (validate_interrupt()) {
+      interrupt_active_ = true;
+      interrupt_miss_count_ = 0;
+      roode::Roode::log_event("interrupt_recovered");
+      use_int = true;
+    } else {
+      last_interrupt_retry_ = millis();
+    }
+  }
+
   status = this->sensor.StartRanging();
   if (status != VL53L1_ERROR_NONE) {
     ESP_LOGE(TAG, "Failed to start ranging, error code: %d", status);
     return {};
   }
 
-  // Wait for the measurement to be ready
-  // TODO use interrupt_pin, if given, to await data ready instead of polling
-  uint8_t dataReady = false;
+  // Wait for measurement ready using interrupt pin when available
+  bool initial_state = false;
+  if (use_int) {
+    initial_state = this->interrupt_pin.value()->digital_read();
+  }
   auto start_time = millis();
   while (!dataReady && (millis() - start_time) < this->timeout) {
-    status = this->sensor.CheckForDataReady(&dataReady);
-    if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGE(TAG, "Failed to check if data is ready, error code: %d", status);
-      return {};
+    if (use_int) {
+      if (this->interrupt_pin.value()->digital_read() != initial_state) {
+        dataReady = true;
+      }
+    } else {
+      status = this->sensor.CheckForDataReady(&dataReady);
+      if (status != VL53L1_ERROR_NONE) {
+        ESP_LOGE(TAG, "Failed to check if data is ready, error code: %d", status);
+        return {};
+      }
     }
     delay(1);
     App.feed_wdt();
+  }
+  if (use_int && !dataReady) {
+    roode::Roode::log_event("int_pin_missed_sensor_" + std::to_string(sensor_id_));
+    roode::Roode::log_event("int_pin_missed");
+    interrupt_miss_count_++;
+    if (interrupt_miss_count_ >= 5) {
+      roode::Roode::log_event("interrupt_fallback_polling");
+      interrupt_active_ = false;
+      last_interrupt_retry_ = millis();
+    } else {
+      roode::Roode::log_event("interrupt_fallback");
+    }
+    // Fallback to polling for this measurement
+    start_time = millis();
+    while (!dataReady && (millis() - start_time) < this->timeout) {
+      status = this->sensor.CheckForDataReady(&dataReady);
+      if (status != VL53L1_ERROR_NONE) {
+        ESP_LOGE(TAG, "Failed to check if data is ready, error code: %d", status);
+        return {};
+      }
+      delay(1);
+      App.feed_wdt();
+    }
   }
   if (!dataReady) {
     ESP_LOGW(TAG, "Timed out waiting for measurement ready");
@@ -227,11 +312,18 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
     this->sensor.StopRanging();
     if (this->xshut_pin.has_value()) {
       this->xshut_pin.value()->digital_write(false);
+      roode::Roode::log_event("xshut_pulse_off_sensor_" + std::to_string(sensor_id_));
+      roode::Roode::log_event("xshut_pulse_off");
       ESP_LOGW(TAG, "XShut pin set LOW - resetting sensor");
-      delay(10);
+      delay(100);
       this->xshut_pin.value()->digital_write(true);
+      roode::Roode::log_event("xshut_reinitialize_sensor_" + std::to_string(sensor_id_));
+      roode::Roode::log_event("xshut_reinitialize");
       ESP_LOGD(TAG, "XShut pin set HIGH - reset complete");
       this->wait_for_boot();
+      roode::Roode::log_event("sensor_" + std::to_string(sensor_id_) + ".recovered_via_xshut");
+      roode::Roode::log_event("sensor.recovered_via_xshut");
+      recovery_count_++;
     }
     return {};
   }
@@ -255,6 +347,9 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
     ESP_LOGE(TAG, "Could not stop ranging, error code: %d", status);
     return {};
   }
+
+  if (use_int)
+    interrupt_miss_count_ = 0;
 
   ESP_LOGV(TAG, "Finished distance read: %d", distance);
   return {distance};
@@ -290,31 +385,20 @@ bool VL53L1X::check_features() {
   }
 
   if (this->interrupt_pin.has_value()) {
-    bool initial = this->interrupt_pin.value()->digital_read();
-    ESP_LOGD(TAG, "Interrupt pin initial state: %d", initial);
-    auto status = this->sensor.StartRanging();
-    if (status == VL53L1_ERROR_NONE) {
-      auto start = millis();
-      while ((millis() - start) < this->timeout) {
-        if (this->interrupt_pin.value()->digital_read() != initial) {
-          ESP_LOGD(TAG, "Interrupt pin state changed - measurement ready");
-          int_ok = true;
-          break;
-        }
-        App.feed_wdt();
-      }
-      if (!int_ok)
-        ESP_LOGD(TAG, "Interrupt pin did not change state during validation");
-      this->sensor.ClearInterrupt();
-      this->sensor.StopRanging();
-    }
+    int_ok = validate_interrupt();
     if (!int_ok) {
       ESP_LOGE(TAG, "Interrupt pin validation failed, falling back to polling");
-      this->interrupt_pin.reset();
-      ESP_LOGW(TAG, "Interrupt pin disabled due to validation failure");
+      interrupt_active_ = false;
+      interrupt_miss_count_ = 0;
+      last_interrupt_retry_ = millis();
     } else {
       ESP_LOGI(TAG, "Interrupt pin working");
+      interrupt_active_ = true;
+      roode::Roode::log_event("interrupt_initialized");
+      interrupt_miss_count_ = 0;
     }
+  } else {
+    interrupt_active_ = false;
   }
 
   if (!this->interrupt_pin.has_value()) {
@@ -329,6 +413,31 @@ bool VL53L1X::check_features() {
   }
 
   return !this->is_failed();
+}
+
+bool VL53L1X::validate_interrupt() {
+  bool ok = false;
+  if (!this->interrupt_pin.has_value())
+    return false;
+  bool initial = this->interrupt_pin.value()->digital_read();
+  ESP_LOGD(TAG, "Interrupt pin initial state: %d", initial);
+  auto status = this->sensor.StartRanging();
+  if (status == VL53L1_ERROR_NONE) {
+    auto start = millis();
+    while ((millis() - start) < this->timeout) {
+      if (this->interrupt_pin.value()->digital_read() != initial) {
+        ESP_LOGD(TAG, "Interrupt pin state changed - measurement ready");
+        ok = true;
+        break;
+      }
+      App.feed_wdt();
+    }
+    if (!ok)
+      ESP_LOGD(TAG, "Interrupt pin did not change state during validation");
+    this->sensor.ClearInterrupt();
+    this->sensor.StopRanging();
+  }
+  return ok;
 }
 
 }  // namespace vl53l1x

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -2,6 +2,7 @@
 #include <math.h>
 
 #include "VL53L1X_ULD.h"
+#include <vector>
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
@@ -29,6 +30,20 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   optional<uint16_t> read_distance(ROI *roi, VL53L1_Error &error);
   void set_ranging_mode(const RangingMode *mode);
 
+  optional<bool> get_xshut_state() {
+    if (this->xshut_pin.has_value())
+      return this->xshut_pin.value()->digital_read();
+    return {};
+  }
+  optional<bool> get_interrupt_state() {
+    if (this->interrupt_pin.has_value())
+      return this->interrupt_pin.value()->digital_read();
+    return {};
+  }
+  int get_recovery_count() const { return recovery_count_; }
+  void set_sensor_id(uint8_t id) { sensor_id_ = id; }
+  void set_desired_address(uint8_t addr) { desired_address_ = addr; }
+
   void set_xshut_pin(GPIOPin *pin) { this->xshut_pin = pin; }
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin = pin; }
   optional<const RangingMode *> get_ranging_mode_override() { return this->ranging_mode_override; }
@@ -36,6 +51,8 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   void set_offset(int16_t val) { this->offset = val; }
   void set_xtalk(uint16_t val) { this->xtalk = val; }
   void set_timeout(uint16_t val) { this->timeout = val; }
+
+  bool is_interrupt_enabled() const { return interrupt_active_ && interrupt_pin.has_value(); }
 
  protected:
   VL53L1X_ULD sensor;
@@ -47,7 +64,11 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   optional<int16_t> offset{};
   optional<uint16_t> xtalk{};
   uint16_t timeout{};
-  ROI *last_roi{};
+ ROI *last_roi{};
+ int recovery_count_{0};
+  uint8_t sensor_id_{0};
+  uint8_t desired_address_{0x29};
+  static std::vector<VL53L1X *> sensors;
 
   VL53L1_Error init();
   VL53L1_Error wait_for_boot();
@@ -58,6 +79,11 @@ class VL53L1X : public i2c::I2CDevice, public Component {
    * @return false when the sensor becomes unresponsive while testing pins.
    */
   bool check_features();
+  bool validate_interrupt();
+
+  bool interrupt_active_{false};
+  uint8_t interrupt_miss_count_{0};
+  uint32_t last_interrupt_retry_{0};
 };
 
 }  // namespace vl53l1x

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -22,7 +22,7 @@ wifi:
     - ssid: !secret ssid1
       password: !secret ssid1_password
   use_address: $devicename
-  fast_connect: True
+  fast_connect: true
   power_save_mode: light
   domain: .local
 
@@ -35,16 +35,6 @@ api:
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
-    - service: set_max_threshold
-      variables:
-        newThreshold: int
-      then:
-        - lambda: "id(roode_platform)->set_max_threshold_percentage(newThreshold);id(roode_platform)->recalibration();"
-    - service: set_min_threshold
-      variables:
-        newThreshold: int
-      then:
-        - lambda: "id(roode_platform)->set_min_threshold_percentage(newThreshold);id(roode_platform)->recalibration();"
 
 ota:
   password: !secret ota_password
@@ -65,11 +55,20 @@ i2c:
 
 # VL53L1X sensor configuration is separate from Roode people counting algorithm
 vl53l1x:
+  sensor_id: 1
   calibration:
     # The ranging mode is different based on how long the distance is that the sensor need to measure.
     # The longer the distance, the more time the sensor needs to take a measurement.
     # Available options are: auto, shortest, short, medium, long, longer, longest
     ranging: auto
+  pins:
+    xshut:
+      number: GPIO3
+      mode: OUTPUT_PULLUP
+      ignore_strapping_warning: true
+    interrupt:
+      number: GPIO1
+      mode: INPUT_PULLUP
 
 roode:
   id: roode_platform
@@ -110,6 +109,8 @@ binary_sensor:
   - platform: roode
     presence_sensor:
       name: $friendly_name presence
+    sensor_xshut_state:
+      name: $friendly_name xshut state
 
 sensor:
   - platform: roode
@@ -139,7 +140,11 @@ sensor:
     roi_width_exit:
       name: $friendly_name ROI width zone 1
     sensor_status:
-      name: Sensor Status
+      name: $friendly_name sensor status
+    interrupt_status:
+      name: $friendly_name interrupt status
+    manual_adjustment_count:
+      name: $friendly_name manual adjusts
   - platform: wifi_signal
     name: $friendly_name RSSI
     update_interval: 60s
@@ -175,6 +180,9 @@ text_sensor:
   - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
+  - platform: roode
+    enabled_features:
+      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -19,7 +19,7 @@ wifi:
     - ssid: !secret ssid1
       password: !secret ssid1_password
   use_address: $devicename
-  fast_connect: True
+  fast_connect: true
   power_save_mode: none
   domain: .local
 
@@ -52,14 +52,20 @@ i2c:
 
 # Sensor is configured separately from Roode people counting algorithm
 vl53l1x:
+  sensor_id: 1
   calibration:
     # ranging: longest # defaults to "auto" for formerly "calibration: true"
     # offset: 8
     # xtalk: 53406
   # These pins are not yet implemented but they are passed into class now
   pins:
-    # xshut: 3 # shutdown pin to change address or multiple sensors
-    # interrupt: 1 # hardware callback when measurement is ready
+    xshut:
+      number: GPIO3
+      mode: OUTPUT_PULLUP
+      ignore_strapping_warning: true
+    interrupt:
+      number: GPIO1
+      mode: INPUT_PULLUP
 roode:
   id: roode_platform
   # I removed the { size: 1 } option here since it was redundant.
@@ -106,6 +112,8 @@ binary_sensor:
   - platform: roode
     presence_sensor:
       name: $friendly_name presence
+    sensor_xshut_state:
+      name: $friendly_name xshut state
 
 sensor:
   - platform: roode
@@ -137,7 +145,11 @@ sensor:
     roi_width_exit:
       name: $friendly_name ROI width zone 1
     sensor_status:
-      name: Sensor Status
+      name: $friendly_name sensor status
+    interrupt_status:
+      name: $friendly_name interrupt status
+    manual_adjustment_count:
+      name: $friendly_name manual adjusts
 
   - platform: wifi_signal
     name: $friendly_name RSSI
@@ -174,6 +186,9 @@ text_sensor:
   - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
+  - platform: roode
+    enabled_features:
+      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -19,7 +19,7 @@ wifi:
     - ssid: !secret ssid1
       password: !secret ssid1_password
   use_address: $devicename
-  fast_connect: True
+  fast_connect: true
   power_save_mode: none
   domain: .local
 
@@ -52,11 +52,20 @@ i2c:
 
 # VL53L1X sensor configuration is separate from Roode people counting algorithm
 vl53l1x:
+  sensor_id: 1
   calibration:
     # The ranging mode is different based on how long the distance is that the sensor need to measure.
     # The longer the distance, the more time the sensor needs to take a measurement.
     # Available options are: auto, shortest, short, medium, long, longer, longest
     ranging: auto
+  pins:
+    xshut:
+      number: GPIO3
+      mode: OUTPUT_PULLUP
+      ignore_strapping_warning: true
+    interrupt:
+      number: GPIO1
+      mode: INPUT_PULLUP
 
 roode:
   id: roode_platform
@@ -98,6 +107,8 @@ binary_sensor:
   - platform: roode
     presence_sensor:
       name: $friendly_name presence
+    sensor_xshut_state:
+      name: $friendly_name xshut state
 
 sensor:
   - platform: roode
@@ -127,7 +138,11 @@ sensor:
     roi_width_exit:
       name: $friendly_name ROI width zone 1
     sensor_status:
-      name: Sensor Status
+      name: $friendly_name sensor status
+    interrupt_status:
+      name: $friendly_name interrupt status
+    manual_adjustment_count:
+      name: $friendly_name manual adjusts
 
   - platform: wifi_signal
     name: $friendly_name RSSI
@@ -164,6 +179,9 @@ text_sensor:
   - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
+  - platform: roode
+    enabled_features:
+      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -16,7 +16,7 @@ wifi:
     - ssid: !secret ssid1
       password: !secret ssid1_password
   use_address: $devicename
-  fast_connect: True
+  fast_connect: true
   power_save_mode: none
   domain: .local
 
@@ -48,14 +48,20 @@ i2c:
   scl: 5
 # Sensor is configured separately from Roode people counting algorithm
 vl53l1x:
+  sensor_id: 1
   calibration:
     # ranging: longest # defaults to "auto" for formerly "calibration: true"
     # offset: 8
     # xtalk: 53406
   # These pins are not yet implemented but they are passed into class now
   pins:
-    # xshut: 3 # shutdown pin to change address or multiple sensors
-    # interrupt: 1 # hardware callback when measurement is ready
+    xshut:
+      number: GPIO3
+      mode: OUTPUT_PULLUP
+      ignore_strapping_warning: true
+    interrupt:
+      number: GPIO1
+      mode: INPUT_PULLUP
 roode:
   id: roode_platform
   # I removed the { size: 1 } option here since it was redundant.
@@ -102,6 +108,8 @@ binary_sensor:
   - platform: roode
     presence_sensor:
       name: $friendly_name presence
+    sensor_xshut_state:
+      name: $friendly_name xshut state
 
 sensor:
   - platform: roode
@@ -133,7 +141,11 @@ sensor:
     roi_width_exit:
       name: $friendly_name ROI width zone 1
     sensor_status:
-      name: Sensor Status
+      name: $friendly_name sensor status
+    interrupt_status:
+      name: $friendly_name interrupt status
+    manual_adjustment_count:
+      name: $friendly_name manual adjusts
 
   - platform: wifi_signal
     name: $friendly_name RSSI
@@ -170,6 +182,9 @@ text_sensor:
   - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
+  - platform: roode
+    enabled_features:
+      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human


### PR DESCRIPTION
## Summary
- add filter mode enum and calibration persistence
- implement dual-core sensor task and FSM timeout
- add median filtering and fail-safe zone calibration
- implement CPU optimization plan and percentile filtering

## Testing
- `python3 -m py_compile components/roode/*.py`
- `platformio run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687294c7f9688330a3f58eb371f8e0df