### PR TITLE
Improve logging and feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature is on its own line
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
 - Interrupt mode logs only report errors
@@ -317,8 +317,11 @@ text_sensor:
     enabled_features:
       name: $friendly_name enabled features
 ```
-The features string lists items as `name:value` pairs separated by commas. The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`, `cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
-Memory values are printed with KB or MB units and the calibration time uses the device's clock in `HH:MM`.
+The features string lists items as `name:value` pairs separated by new lines. The
+current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`, `cpu_cores`,
+`ram`, `flash`, `calibration_value` and `calibration`.
+Memory values are printed with KB or MB units and the calibration time uses the
+device's clock in `h:MMAM/PM`.
 
 ### Threshold distance
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
+- Features text sensor also reports RAM, flash, CPU cores, ROI and calibration settings
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
@@ -308,6 +309,7 @@ text_sensor:
     enabled_features:
       name: $friendly_name enabled features
 ```
+The features string lists items as name:value pairs separated by commas, including RAM, flash, CPU cores, ROI sizes, orientation and calibration persistence.
 
 ### Threshold distance
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
-- Repeated interrupt pin messages are more aggressively throttled to keep the log readable
+- Interrupt mode messages are throttled to once every 5 seconds for readability
 - Logs are color-coded: green for normal, yellow for info, and red for failures
 
 ## Hardware Recommendation

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature appears on its own line
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature appears on its own line and updates after calibration
 - If the device clock is unset, the calibration time shows "unknown"
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes

--- a/README.md
+++ b/README.md
@@ -36,10 +36,12 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
+- Enabled features now include total RAM, flash size and CPU core count
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
+- Repeated interrupt pin messages are throttled to keep the log readable
 - Logs are color-coded: green for normal, yellow for info, and red for failures
 
 ## Hardware Recommendation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
-- Enabled features now include RAM, flash, and CPU cores; each feature is published as comma-separated `name:value` pairs
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
-- Enabled features now include RAM, flash, and CPU cores; each feature is published as `name:value` for easy parsing
+- Enabled features now include RAM, flash, and CPU cores; each feature is published as comma-separated `name:value` pairs
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature is on its own line
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature appears on its own line
+- If the device clock is unset, the calibration time shows "unknown"
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
 - Interrupt mode logs only report errors
@@ -317,11 +318,12 @@ text_sensor:
     enabled_features:
       name: $friendly_name enabled features
 ```
-The features string lists items as `name:value` pairs separated by new lines. The
-current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`, `cpu_cores`,
-`ram`, `flash`, `calibration_value` and `calibration`.
-Memory values are printed with KB or MB units and the calibration time uses the
-device's clock in `h:MMAM/PM`.
+The features string lists items as `name:value` pairs separated by new lines.
+The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`,
+`cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
+Memory values are printed with KB or MB units. Calibration time uses the device
+clock in `h:MMAM/PM` format or displays `unknown` if the clock has not been
+initialised.
 
 ### Threshold distance
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature appears on its own line and updates after calibration
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature appears on its own line and updates after calibration or when core/refresh modes change
 - If the device clock is unset, the calibration time shows "unknown"
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
-- Interrupt mode messages are throttled to once every 5 seconds for readability
+- Interrupt mode logs only report errors
 - Logs are color-coded: green for normal, yellow for info, and red for failures
 
 ## Hardware Recommendation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor also reports RAM, flash, CPU cores, ROI and calibration settings
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes and calibration info
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
@@ -309,7 +309,8 @@ text_sensor:
     enabled_features:
       name: $friendly_name enabled features
 ```
-The features string lists items as name:value pairs separated by commas, including RAM, flash, CPU cores, ROI sizes, orientation and calibration persistence.
+The features string lists items as `name:value` pairs separated by commas. The current output includes:
+`xshut`, `refresh`, `cpu_mode`, `cpu`, `cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
 
 ### Threshold distance
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes and calibration info
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
@@ -309,8 +309,8 @@ text_sensor:
     enabled_features:
       name: $friendly_name enabled features
 ```
-The features string lists items as `name:value` pairs separated by commas. The current output includes:
-`xshut`, `refresh`, `cpu_mode`, `cpu`, `cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
+The features string lists items as `name:value` pairs separated by commas. The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`, `cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
+Memory values are printed with KB or MB units and the calibration time uses the device's clock in `HH:MM`.
 
 ### Threshold distance
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time; each feature appears on its own line and updates after calibration or when core/refresh modes change
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with KB/MB/GB units and the last calibration time; each feature appears on its own line and updates after calibration or when core/refresh modes change
 - If the device clock is unset, the calibration time shows "unknown"
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
@@ -321,9 +321,9 @@ text_sensor:
 The features string lists items as `name:value` pairs separated by new lines.
 The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`,
 `cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
-Memory values are printed with KB or MB units. Calibration time uses the device
-clock in `h:MMAM/PM` format or displays `unknown` if the clock has not been
-initialised.
+Memory values are printed with **KB**, **MB** or **GB** units. Calibration time
+uses the device clock in `h:MMAM/PM` format or displays `unknown` if the clock
+has not been initialised.
 
 ### Threshold distance
 

--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
-- Enabled features now include total RAM, flash size and CPU core count
+- Enabled features now include total RAM, flash size and CPU core count with units
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
-- Repeated interrupt pin messages are throttled to keep the log readable
+- Repeated interrupt pin messages are more aggressively throttled to keep the log readable
 - Logs are color-coded: green for normal, yellow for info, and red for failures
 
 ## Hardware Recommendation

--- a/README.md
+++ b/README.md
@@ -21,24 +21,32 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 
 ## Features
 
+### Hardware management
+
 - Automatic sensor restart using the xshut pin when a measurement times out
 - Cleaner memory management and sensor shutdown on reboot
 - Startup check that logs whether the xshut and interrupt pins are functional
 - If a pin test fails at boot the feature is automatically disabled so the sensor continues operating
 - Xshut and interrupt pins use internal pull-ups so no extra resistors are needed
-- Optional sensors report loop time, CPU usage, RAM and flash usage percentages
+- Multiple sensors can share the I²C bus using XSHUT multiplexing
+- Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
+
+### Sensor and algorithm
+
 - Fail-safe recalibration restores thresholds if a zone stays active
 - Calibration data can persist in flash across reboots
 - Dual-core tasking keeps distance polling responsive on ESP32 with automatic retry and fallback
 - Median/percentile filtering smooths jitter with a configurable window
 - State machine timeouts reset the FSM if a transition stalls
 - Optional CPU optimizations kick in automatically above 90% usage and revert once load drops
-- Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
-- Multiple sensors can share the I²C bus using XSHUT multiplexing
-- Text sensor reports the list of enabled and fallback features
-- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time
+
+### Diagnostics and logging
+
+- Optional sensors report loop time, CPU usage, RAM and flash usage percentages
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
+- Text sensor reports the list of enabled and fallback features
+- Features text sensor reports XSHUT and refresh status, CPU details, memory sizes with units and the last calibration time
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures
 - Event logs detail sensor power cycles, interrupt fallbacks with reasons, manual adjustments, and core mode changes
 - Interrupt mode logs only report errors

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ People counter working with any smart home system which supports ESPHome/MQTT li
 - Interrupt pin support avoids polling overhead with automatic fallback; logs show the interrupt pin level and why polling may be used
 - Multiple sensors can share the I²C bus using XSHUT multiplexing
 - Text sensor reports the list of enabled and fallback features
-- Enabled features now include total RAM, flash size and CPU core count with units
+- Enabled features now include RAM, flash, and CPU cores; each feature is published as `name:value` for easy parsing
 - Manual adjustment counter tracks user corrections to the people count
 - Diagnostic sensors report the state of the interrupt and XSHUT pins
 - Optional logging of fallback events helps troubleshoot interrupt or XSHUT failures

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -244,16 +244,17 @@ void Roode::setup() {
 
   auto fmt_time = [](uint32_t epoch) {
     if (epoch == 0)
-      return std::string("00:00");
+      return std::string("unknown");
     time_t t = epoch;
-    struct tm tm;
-    localtime_r(&t, &tm);
+    struct tm tm_time;
+    if (!localtime_r(&t, &tm_time))
+      return std::string("unknown");
     char buf[8];
-    int hour = tm.tm_hour % 12;
+    int hour = tm_time.tm_hour % 12;
     if (hour == 0)
       hour = 12;
-    snprintf(buf, sizeof(buf), "%d:%02d%cM", hour, tm.tm_min,
-             tm.tm_hour >= 12 ? 'P' : 'A');
+    snprintf(buf, sizeof(buf), "%d:%02d%cM", hour, tm_time.tm_min,
+             tm_time.tm_hour >= 12 ? 'P' : 'A');
     return std::string(buf);
   };
 
@@ -280,8 +281,6 @@ void Roode::setup() {
   for (auto &f : features) {
     feature_list += f.first + ":" + f.second + "\n";
   }
-  if (!feature_list.empty())
-    feature_list.pop_back();
   if (enabled_features_sensor != nullptr)
     enabled_features_sensor->publish_state(feature_list);
   log_event(std::string("features_enabled: ") + feature_list);

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -17,7 +17,8 @@ void Roode::log_event(const std::string &msg) {
   if (msg == "int_pin_missed" || msg.rfind("int_pin_missed_sensor_", 0) == 0 ||
       msg == "use_interrupt_mode" || msg.rfind("use_interrupt_mode_", 0) == 0) {
     uint32_t now = millis();
-    if (now - last_interrupt_log < INTERRUPT_LOG_INTERVAL_MS) {
+    if (last_interrupt_log != 0 &&
+        now - last_interrupt_log < INTERRUPT_LOG_INTERVAL_MS) {
       return;
     }
     last_interrupt_log = now;

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -11,6 +11,7 @@ namespace roode {
 
 // When disabled, fallback diagnostics are omitted from the log to reduce noise.
 bool Roode::log_fallback_events_ = false;
+Roode *Roode::instance_ = nullptr;
 void Roode::log_event(const std::string &msg) {
   if (!log_fallback_events_) {
     if (msg == "interrupt_fallback" || msg == "interrupt_fallback_polling")
@@ -99,6 +100,13 @@ void Roode::log_event(const std::string &msg) {
 
   std::string colored = std::string(color) + out + "\033[0m";
   ESP_LOGI(TAG, "%s", colored.c_str());
+  if (instance_ != nullptr) {
+    if (msg == "dual_core_success" || msg == "fallback_single_core" ||
+        msg == "force_single_core" || msg == "interrupt_fallback_polling" ||
+        msg == "interrupt_recovered") {
+      instance_->publish_feature_list();
+    }
+  }
 }
 
 Roode::~Roode() {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -8,21 +8,7 @@ namespace roode {
 
 // When disabled, fallback diagnostics are omitted from the log to reduce noise.
 bool Roode::log_fallback_events_ = false;
-// Track last interrupt log time to avoid spamming the console
-static uint32_t last_interrupt_log = 0;
-static const uint32_t INTERRUPT_LOG_INTERVAL_MS = 5000;  // 5 seconds
-
 void Roode::log_event(const std::string &msg) {
-  // Throttle repeated interrupt messages which can overwhelm the log
-  if (msg == "int_pin_missed" || msg.rfind("int_pin_missed_sensor_", 0) == 0 ||
-      msg == "use_interrupt_mode" || msg.rfind("use_interrupt_mode_", 0) == 0) {
-    uint32_t now = millis();
-    if (last_interrupt_log != 0 &&
-        now - last_interrupt_log < INTERRUPT_LOG_INTERVAL_MS) {
-      return;
-    }
-    last_interrupt_log = now;
-  }
   if (!log_fallback_events_) {
     if (msg == "interrupt_fallback" || msg == "interrupt_fallback_polling")
       return;
@@ -82,15 +68,6 @@ void Roode::log_event(const std::string &msg) {
     out += " - sensor " + id + " recovered via XSHUT";
   } else if (msg == "sensor.recovered_via_xshut") {
     out += " - sensor recovered via XSHUT";
-  } else if (msg.rfind("use_interrupt_mode_", 0) == 0) {
-    std::string level = msg.substr(sizeof("use_interrupt_mode_") - 1);
-    out += " - INT pin initial " + level;
-    if (level == "low")
-      out += "; waiting for HIGH";
-    else
-      out += "; waiting for LOW";
-  } else if (msg == "use_interrupt_mode") {
-    out += " - using interrupt mode";
   } else if (msg == "interrupt_fallback_polling" || msg == "interrupt_fallback")
     out += " - INT pin timeout, polling";
   else if (msg == "int_pin_missed")

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -13,8 +13,9 @@ static uint32_t last_interrupt_log = 0;
 static const uint32_t INTERRUPT_LOG_INTERVAL_MS = 5000;  // 5 seconds
 
 void Roode::log_event(const std::string &msg) {
-  // Throttle repeated interrupt miss messages which can overwhelm the log
-  if (msg == "int_pin_missed" || msg.rfind("int_pin_missed_sensor_", 0) == 0) {
+  // Throttle repeated interrupt messages which can overwhelm the log
+  if (msg == "int_pin_missed" || msg.rfind("int_pin_missed_sensor_", 0) == 0 ||
+      msg == "use_interrupt_mode" || msg.rfind("use_interrupt_mode_", 0) == 0) {
     uint32_t now = millis();
     if (now - last_interrupt_log < INTERRUPT_LOG_INTERVAL_MS) {
       return;

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -221,26 +221,12 @@ void Roode::setup() {
 
   std::string feature_list;
 #ifdef CONFIG_IDF_TARGET_ESP32
-  feature_list += std::string("core_mode:") + (use_sensor_task_ ? "dual_core," : "single_core,");
+  feature_list += use_sensor_task_ ? "dual_core," : "single_core,";
 #else
-  feature_list += "core_mode:single_core,";
+  feature_list += "single_core,";
 #endif
-  feature_list += std::string("xshut:") + (distanceSensor->get_xshut_state().has_value() ? "enabled," : "disabled,");
-  feature_list += std::string("interrupt:") + (distanceSensor->is_interrupt_enabled() ? "enabled," : "polling,");
-  auto fmt_mem = [](uint32_t kb) {
-    if (kb >= 1024)
-      return std::to_string(kb / 1024) + "MB";
-    return std::to_string(kb) + "KB";
-  };
-  uint32_t total_heap_kb = ESP.getHeapSize() / 1024;
-  uint32_t total_flash_kb = ESP.getFlashChipSize() / 1024;
-  feature_list += "ram:" + fmt_mem(total_heap_kb) + ',';
-  feature_list += "flash:" + fmt_mem(total_flash_kb) + ',';
-#ifdef CONFIG_IDF_TARGET_ESP32
-  feature_list += "cpu_cores:" + std::to_string(ESP.getChipCores()) + ',';
-#else
-  feature_list += "cpu_cores:1,";
-#endif
+  feature_list += distanceSensor->get_xshut_state().has_value() ? "xshut," : "no_xshut,";
+  feature_list += distanceSensor->is_interrupt_enabled() ? "interrupt," : "polling,";
   if (!feature_list.empty())
     feature_list.pop_back();
   if (enabled_features_sensor != nullptr)

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -248,8 +248,12 @@ void Roode::setup() {
     time_t t = epoch;
     struct tm tm;
     localtime_r(&t, &tm);
-    char buf[6];
-    snprintf(buf, sizeof(buf), "%02d:%02d", tm.tm_hour, tm.tm_min);
+    char buf[8];
+    int hour = tm.tm_hour % 12;
+    if (hour == 0)
+      hour = 12;
+    snprintf(buf, sizeof(buf), "%d:%02d%cM", hour, tm.tm_min,
+             tm.tm_hour >= 12 ? 'P' : 'A');
     return std::string(buf);
   };
 
@@ -274,7 +278,7 @@ void Roode::setup() {
 
   std::string feature_list;
   for (auto &f : features) {
-    feature_list += f.first + ":" + f.second + ",";
+    feature_list += f.first + ":" + f.second + "\n";
   }
   if (!feature_list.empty())
     feature_list.pop_back();

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -486,7 +486,7 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   calibration_data_[zone_id].baseline_mm = z->threshold->idle;
   calibration_data_[zone_id].threshold_min_mm = z->threshold->min;
   calibration_data_[zone_id].threshold_max_mm = z->threshold->max;
-  calibration_data_[zone_id].last_calibrated_ts = time(nullptr);
+  calibration_data_[zone_id].last_calibrated_ts = static_cast<uint32_t>(time(nullptr));
   if (calibration_persistence_) {
     calibration_prefs_[zone_id].save(&calibration_data_[zone_id]);
   }
@@ -602,8 +602,8 @@ void Roode::calibrate_zones() {
   App.feed_wdt();
   publish_sensor_configuration(entry, exit, false);
   if (calibration_persistence_) {
-    calibration_data_[0] = {entry->threshold->idle, entry->threshold->min, entry->threshold->max, time(nullptr)};
-    calibration_data_[1] = {exit->threshold->idle, exit->threshold->min, exit->threshold->max, time(nullptr)};
+    calibration_data_[0] = {entry->threshold->idle, entry->threshold->min, entry->threshold->max, static_cast<uint32_t>(time(nullptr))};
+    calibration_data_[1] = {exit->threshold->idle, exit->threshold->min, exit->threshold->max, static_cast<uint32_t>(time(nullptr))};
     calibration_prefs_[0].save(&calibration_data_[0]);
     calibration_prefs_[1].save(&calibration_data_[1]);
   }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -664,11 +664,11 @@ void Roode::publish_feature_list() {
   auto fmt_bytes = [](uint32_t bytes) {
     char buf[16];
     if (bytes >= 1024UL * 1024UL * 1024UL)
-      snprintf(buf, sizeof(buf), "%uG", bytes / 1024 / 1024 / 1024);
+      snprintf(buf, sizeof(buf), "%uGB", bytes / 1024 / 1024 / 1024);
     else if (bytes >= 1024 * 1024)
-      snprintf(buf, sizeof(buf), "%uM", bytes / 1024 / 1024);
+      snprintf(buf, sizeof(buf), "%uMB", bytes / 1024 / 1024);
     else
-      snprintf(buf, sizeof(buf), "%uk", bytes / 1024);
+      snprintf(buf, sizeof(buf), "%uKB", bytes / 1024);
     return std::string(buf);
   };
 

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -58,6 +58,7 @@ static int time_budget_in_ms_max = 200;  // max range: 4m
 
 class Roode : public PollingComponent {
  public:
+  Roode() { instance_ = this; }
   void setup() override;
   void update() override;
   void loop() override;
@@ -182,6 +183,7 @@ class Roode : public PollingComponent {
   uint16_t polling_interval_ms_{10};
 
   static bool log_fallback_events_;
+  static Roode *instance_;
   int manual_adjustment_count_{0};
   float expected_counter_{0};
   bool force_single_core_{false};

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -201,6 +201,7 @@ class Roode : public PollingComponent {
   bool handle_sensor_status();
   void calibrateDistance();
   void calibrate_zones();
+  void publish_feature_list();
   const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
   void publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax);
   void updateCounter(int delta);

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -266,8 +266,6 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
   bool initial_state = false;
   if (use_int) {
     initial_state = this->interrupt_pin.value()->digital_read();
-    roode::Roode::log_event("use_interrupt_mode");
-    roode::Roode::log_event("use_interrupt_mode_" + std::string(initial_state ? "high" : "low"));
   }
   auto start_time = millis();
   while (!dataReady && (millis() - start_time) < this->timeout) {


### PR DESCRIPTION
## Summary
- throttle repeated interrupt messages
- show RAM, flash and CPU information in the enabled features list
- document new features and logging change in README

## Testing
- `esphome config ci/esp32.yaml` *(fails: Could not install esphome)*

------
https://chatgpt.com/codex/tasks/task_e_687673a3fb0483308397292e4ea37c19