### PR TITLE
Fix invalid services and expose threshold API

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,9 +375,9 @@ text_sensor:
 
 Another crucial choice is the one corresponding to the threshold. Indeed a movement is detected whenever the distance read by the sensor is below this value. The code contains a vector as threshold, as one (as myself) might need a different threshold for each zone.
 
-The threshold is automatically calculated by the sensor. To do so it is necessary to position the sensor and, after turning it on, wait for 10 seconds without passing under it. After this time, the average of the measures for each zone will be computed and the threshold for each ROI will correspond to 80% of the average value. Also the value of 80% can be modified in the code, by editing the variable `max_threshold_percentage` and `min_threshold_percentage`.
+The threshold is automatically calculated by the sensor. After power on wait about 10 seconds without passing under it so the idle distance can be sampled. By default the maximum threshold is set to 80% of this distance and the minimum to 15%.  These percentages can be changed at runtime using the `set_entry_threshold_percentages()` and `set_exit_threshold_percentages()` methods.
 
-If you install the sensor e.g 20cm over a door you don't want to count the door open and closing. In this case you should set the `min_threshold_percentage` to about `10`.
+If you install the sensor e.g. 20 cm above a door you don't want to count the door opening and closing. In this case call `set_entry_threshold_percentages(10, 80)` so movements closer than 10 % are ignored.
 
 Example:
 
@@ -385,8 +385,7 @@ Example:
 Mounting height:    2200mm
 Door height:        2000mm
 Person height:      1800mm
-max_threshold_percentage: 80% = 1760
-min_threshold_percentage: 10% = 200
+set_entry_threshold_percentages(10, 80)
 
 All distances smaller than 200mm and greater than 1760mm will be ignored.
 ```

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -26,7 +26,6 @@ static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
 static const char *const CALIBRATION = "Sensor Calibration";
 
-
 /*
 Use the VL53L1X_SetTimingBudget function to set the TB in milliseconds. The TB
 values available are [15, 20, 33, 50, 100, 200, 500]. This function must be
@@ -128,6 +127,8 @@ class Roode : public PollingComponent {
   }
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
+  void set_entry_threshold_percentages(uint8_t min, uint8_t max) { entry->set_threshold_percentages(min, max); }
+  void set_exit_threshold_percentages(uint8_t min, uint8_t max) { exit->set_threshold_percentages(min, max); }
   void apply_cpu_optimizations(float cpu);
   void reset_cpu_optimizations(float cpu);
   void update_metrics();
@@ -221,4 +222,3 @@ class Roode : public PollingComponent {
 
 }  // namespace roode
 }  // namespace esphome
-

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -92,8 +92,12 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
   } else {
     int avg = sum / zone_distances.size();
     threshold->idle = avg;
-    threshold->max = avg * 0.80;
-    threshold->min = avg * 0.15;
+    uint8_t max_pct = threshold->max_percentage.value_or(80);
+    uint8_t min_pct = threshold->min_percentage.value_or(15);
+    threshold->max_percentage = max_pct;
+    threshold->min_percentage = min_pct;
+    threshold->max = (avg * max_pct) / 100;
+    threshold->min = (avg * min_pct) / 100;
   }
 
   ESP_LOGI(CALIBRATION, "Calibrated threshold for zone. zoneId: %d, idle: %d, min: %d (%d%%), max: %d (%d%%)", id,
@@ -149,6 +153,14 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
 
 uint16_t Zone::getDistance() const { return this->last_distance; }
 uint16_t Zone::getMinDistance() const { return this->min_distance; }
+
+void Zone::set_threshold_percentages(uint8_t min_percent, uint8_t max_percent) {
+  threshold->min_percentage = min_percent;
+  threshold->max_percentage = max_percent;
+  if (threshold->idle > 0) {
+    threshold->min = (threshold->idle * min_percent) / 100;
+    threshold->max = (threshold->idle * max_percent) / 100;
+  }
+}
 }  // namespace roode
 }  // namespace esphome
-

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -39,6 +39,7 @@ class Zone {
   void reset_roi(uint8_t default_center);
   void calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
+  void set_threshold_percentages(uint8_t min_percent, uint8_t max_percent);
   const uint8_t id;
   uint16_t getDistance() const;
   uint16_t getMinDistance() const;
@@ -68,4 +69,3 @@ class Zone {
 };
 }  // namespace roode
 }  // namespace esphome
-

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -35,16 +35,6 @@ api:
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
-    - service: set_max_threshold
-      variables:
-        newThreshold: int
-      then:
-        - lambda: "id(roode_platform)->set_max_threshold_percentage(newThreshold);id(roode_platform)->recalibration();"
-    - service: set_min_threshold
-      variables:
-        newThreshold: int
-      then:
-        - lambda: "id(roode_platform)->set_min_threshold_percentage(newThreshold);id(roode_platform)->recalibration();"
 
 ota:
   password: !secret ota_password


### PR DESCRIPTION
## Summary
- drop non-existent threshold services from the example
- add runtime API for entry/exit threshold percentages
- document new API

## Testing
- `clang-format -i components/roode/zone.h components/roode/zone.cpp components/roode/roode.h`

------
https://chatgpt.com/codex/tasks/task_e_6876f74326c883309b261597aa674bd6