### PR TITLE
Unify sampling and filter window options

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ roode:
   # Smooth out measurements by using the minimum distance from this number of readings
   # Increase to 4-5 if jitter is a problem; 1 is fastest but noisier
   sampling: 2
+  filter_mode: median  # min, median or percentile10
 
   # The orientation of the two sensor pads in relation to the entryway being tracked.
   # The advised orientation is parallel, but if needed this can be changed to perpendicular.
@@ -182,11 +183,6 @@ roode:
 
   # Persist calibration data so thresholds survive restarts
   calibration_persistence: true
-
-  # Jitter reduction options
-  filter_mode: median  # min, median or percentile10
-  # Increase the window to 7 or 9 for heavy noise, drop to 3 for faster response
-  filter_window: 5     # number of samples used by the filter
   # Log interrupt fallback events and XSHUT recoveries
   log_fallback_events: true
   # Disable dual core tasking if needed
@@ -250,7 +246,7 @@ loop.  You can force single‑core mode with `force_single_core: true`.
 Roode smooths measurements by buffering several readings.  `filter_mode`
 controls how the sample window is combined: `min` uses the smallest value,
 `median` picks the middle value and `percentile10` selects the 10th percentile.
-`filter_window` sets how many samples are stored.
+The window size comes from the `sampling` option.
 
 | Mode | When to use | Pros | Cons |
 | --- | --- | --- | --- |
@@ -274,7 +270,7 @@ controls how the sample window is combined: `min` uses the smallest value,
 | `roode.roi` | Optional | `h16 w6` | Size of measurement window | Narrow doorway or wide hall | Change by 2–4 units or use `auto` to learn | `roi: { height: 16, width: 6 }` | `roi: auto` |
 | `roode.detection_thresholds` | Optional | `min:0% max:85%` | Distance limits for detecting people | Sensor too close or far from traffic | Raise `min` ~5% (or ~50 mm) each time | `detection_thresholds: { min: 5%, max: 85% }` | `detection_thresholds: { min: 50mm, max: 234cm }` |
 | `roode.calibration_persistence` | Optional | `false` | Save thresholds in flash | Sensor reboots often | Enable to keep tuning | `calibration_persistence: false` | `calibration_persistence: true` |
-| `roode.filter_mode` & `roode.filter_window` | Optional | `min` / `5` | How samples are combined and window size | Noisy environment | Use `median`/`percentile10` with larger windows | `filter_mode: min`<br>`filter_window: 5` | `filter_mode: percentile10`<br>`filter_window: 9` |
+| `roode.filter_mode` | Optional | `min` | How samples are combined | Noisy environment | Use `median`/`percentile10` with larger sampling values | `filter_mode: min` | `filter_mode: percentile10` |
 | `roode.log_fallback_events` | Optional | `false` | Record INT/XSHUT fallback events | Debugging unexpected counts | Enable while testing | `log_fallback_events: false` | `log_fallback_events: true` |
 | `roode.force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | `force_single_core: false` | `force_single_core: true` |
 | `roode.zones.invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | `zones: { invert: false }` | `zones: { invert: true }` |
@@ -478,7 +474,7 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | Fail-safe recalibration | Triggers recalibration if a zone stays active too long |
 | Persistent calibration | Calibration data can persist in flash across reboots |
 | Dual-core tasking | Keeps polling responsive on ESP32 with automatic retry/fallback |
-| Filtering options | Median/percentile filters smooth jitter with adjustable window |
+| Filtering options | Median/percentile filters smooth jitter using the sampling buffer |
 | FSM timeouts | Resets the state machine when a transition stalls |
 | CPU optimizations | Automatic optimizations when CPU usage exceeds 90% |
 | Interrupt fallback | Interrupt mode with graceful fallback to polling and logs |

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -32,7 +32,6 @@ CONF_SAMPLING = "sampling"
 CONF_ZONES = "zones"
 CONF_CALIBRATION_PERSISTENCE = "calibration_persistence"
 CONF_FILTER_MODE = "filter_mode"
-CONF_FILTER_WINDOW = "filter_window"
 CONF_LOG_FALLBACK = "log_fallback_events"
 CONF_FORCE_SINGLE_CORE = "force_single_core"
 
@@ -88,7 +87,6 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_DETECTION_THRESHOLDS, default={}): THRESHOLDS_SCHEMA,
         cv.Optional(CONF_CALIBRATION_PERSISTENCE, default=False): cv.boolean,
         cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
-        cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_LOG_FALLBACK, default=False): cv.boolean,
         cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
@@ -113,7 +111,6 @@ async def to_code(config: Dict):
     cg.add(roode.set_sampling_size(config[CONF_SAMPLING]))
     cg.add(roode.set_calibration_persistence(config[CONF_CALIBRATION_PERSISTENCE]))
     cg.add(roode.set_filter_mode(config[CONF_FILTER_MODE]))
-    cg.add(roode.set_filter_window(config[CONF_FILTER_WINDOW]))
     cg.add(roode.set_log_fallback_events(config[CONF_LOG_FALLBACK]))
     cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
     cg.add(roode.set_invert_direction(config[CONF_ZONES][CONF_INVERT]))

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -72,8 +72,10 @@ class Roode : public PollingComponent {
   void set_orientation(Orientation val) { orientation_ = val; }
   void set_sampling_size(uint8_t size) {
     samples = size;
-    entry->set_max_samples(size);
-    exit->set_max_samples(size);
+    filter_window_ = size;
+    default_filter_window_ = size;
+    entry->set_filter_window(size);
+    exit->set_filter_window(size);
   }
   void set_distance_entry(sensor::Sensor *distance_entry_) { distance_entry = distance_entry_; }
   void set_distance_exit(sensor::Sensor *distance_exit_) { distance_exit = distance_exit_; }
@@ -174,9 +176,9 @@ class Roode : public PollingComponent {
   bool fail_safe_triggered_{false};
 
   FilterMode filter_mode_{FILTER_MIN};
-  uint8_t filter_window_{5};
+  uint8_t filter_window_{2};
   FilterMode default_filter_mode_{FILTER_MIN};
-  uint8_t default_filter_window_{5};
+  uint8_t default_filter_window_{2};
 
   bool cpu_optimizations_active_{false};
   uint16_t polling_interval_ms_{10};

--- a/extra_sensors_example.yaml
+++ b/extra_sensors_example.yaml
@@ -7,6 +7,7 @@ vl53l1x:
 
 roode:
   sampling: 2
+  filter_mode: median
 
 sensor:
   - platform: roode

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -84,6 +84,7 @@ roode:
   id: roode_platform
   # Smooth out measurements by using the minimum distance from this number of readings
   sampling: 2
+  filter_mode: median
   # This controls the size of the Region of Interest the sensor should take readings in.
   roi: { height: 16, width: 6 }
   # The detection thresholds for determining whether a measurement should count as a person crossing.

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -71,6 +71,7 @@ roode:
   # I removed the { size: 1 } option here since it was redundant.
   # Can always add back later if we have more sampling paramaters.
   sampling: 2
+  filter_mode: median
   # defaults for both zones
   roi:
     # height: 14

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -71,6 +71,7 @@ roode:
   id: roode_platform
   # Smooth out measurements by using the minimum distance from this number of readings
   sampling: 2
+  filter_mode: median
   # This controls the size of the Region of Interest the sensor should take readings in.
   roi: { height: 16, width: 6 }
   # The detection thresholds for determining whether a measurement should count as a person crossing.

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -67,6 +67,7 @@ roode:
   # I removed the { size: 1 } option here since it was redundant.
   # Can always add back later if we have more sampling paramaters.
   sampling: 1
+  filter_mode: median
   # defaults for both zones
   roi:
     # height: 14


### PR DESCRIPTION
## Summary
- remove `filter_window` from the ESPHome schema
- make `set_sampling_size()` also set the filter window
- default filter window matches the sampling buffer size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68768b5f5b1c8330a11c172b851dbb05