### PR TITLE
Add sampling/filter window tuning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,16 @@ loop.  You can force single‑core mode with `force_single_core: true`.
 
 Roode smooths distance readings in two stages. The driver first averages
 multiple raw measurements using the `sampling` option. Each zone then applies a
-filter across the last few measurements controlled by `filter_mode` and
+filter across the last few averaged values controlled by `filter_mode` and
 `filter_window`.
 
-Increasing either value reduces noise but also slows the response. Start with
-`sampling: 2` and a `filter_window` of `3` and raise them together if your
-environment is unstable. See the table below for how the available filter modes
-behave.
+Raising `sampling` makes each reading steadier while `filter_window` dictates
+how many of those readings must agree before an event fires. Because the filter
+operates on averaged data, the total number of raw readings considered is
+`sampling` multiplied by `filter_window`. This gives better noise rejection at
+the cost of reaction speed. Start with `sampling: 2` and `filter_window: 3` and
+increase them together if your environment is unstable. See the table below for
+how the available filter modes behave.
 
 | Mode | When to use | Pros | Cons |
 | --- | --- | --- | --- |
@@ -268,22 +271,37 @@ behave.
 
 *Averages consecutive raw measurements before filtering.* Increase above `2` only when noise causes flickering.
 
+**Recommended values** moved to the Quick Tips section below.
+
 #### `filter_window`
 
 *Number of past measurements considered by the filter.* `3` is responsive, while `5+` helps in harsh lighting or reflective areas.
+
+**Recommended values** moved to the Quick Tips section below.
 
 Filter mode tips: use `median` to ignore spikes or `percentile10` for gradual noise.
 
 ### Quick Tips Summary
 
-| Setting | Purpose | Good For | Tradeoff |
-| ---------------------- | ---------------------------------- | ------------------------------- | ------------------------ |
-| `sampling: 1` | Fastest response | Controlled lighting, indoors | Higher noise |
-| `sampling: 2–3` | Balanced stability and speed | General use | Slight delay |
-| `filter_window: 3` | General smoothing | Balanced use | Slightly slower response |
-| `filter_window: 5+` | Suppress false triggers | Harsh lighting, sunlight | Laggy detection |
-| `filter_mode: median` | Handle spikes (sunlight, noise) | Flashy or inconsistent lighting | Less smooth transition |
-| `filter_mode: percentile10` | Smooth drifting noise | Consistent background shifts | May react to anomalies |
+The two settings work together: a window of `3` with `sampling: 2` means each
+reported value reflects six raw readings. Raise both when sunlight or
+reflections cause false triggers.
+
+#### Sampling
+
+| `sampling` | When to use | Tradeoff |
+| ---------- | ---------- | -------- |
+| `1` | Fastest response, low noise | Higher noise |
+| `2–3` | Balanced stability and speed | Slight delay |
+| `4+` | Very noisy or unstable areas | Noticeable lag |
+
+#### Filter Window
+
+| `filter_window` | When to use | Tradeoff |
+| --------------- | ---------- | -------- |
+| `3` | General smoothing | Slightly slower response |
+| `5+` | Suppress false triggers | Laggy detection |
+| `1` | Maximum responsiveness | No noise rejection |
 
 ### Configuration Reference
 


### PR DESCRIPTION
## Summary
- document how `sampling` and `filter_window` interact
- include quick tips table for tuning noise filtering

## Testing
- `pip install --user esphome pillow` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6877256ef4c08330bbf54c4b8b05efaf