### PR TITLE
docs: reference Home Assistant setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ A people counter that works with any smart home system that supports ESPHome/MQT
   SDA_PIN 4 (ESP8266) or 21 (ESP32)
   SCL_PIN 5 (ESP8266) or 22 (ESP32)
 
+For setup details with Home Assistant, see the [Home Assistant integration](home_assistant.md).
+
 ## Wiring
 
 The sensors from Pololu, Adafruit and the GY-53 can also be connected to the 5v pin (VIN) as they have a voltage regulator.


### PR DESCRIPTION
## Summary
- link to Home Assistant integration guide from README

## Testing
- `pip install esphome pillow` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68772760e2b88330b397390a9d22a5ee