### PR TITLE
Bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.6.0
+- Auto restart sensors via XSHUT with multiplexing support
+- Startup pin validation with built‑in pull-ups
+- Fail-safe recalibration with calibration data stored in flash
+- Feature text sensor and diagnostics for XSHUT/INT pin states
+- Manual adjustment counter with detailed event logging
+- CPU optimizations using a dual-core task with automatic fallback
+- Filtering options with adjustable window and median/percentile modes
+- Interrupt mode gracefully falls back to polling and logs the reason
+- Colored logs for easier troubleshooting
+
 ## 1.5.1
 - Add diagnostic sensors reporting loop time, CPU usage, and RAM and flash usage percentages
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RooDe
 
-[![GitHub release](https://img.shields.io/github/v/tag/Lyr3x/Roode?style=flat-square)](https://GitHub.com/Lyr3x/Roode/releases/)
+[![GitHub release](https://img.shields.io/badge/release-1.6.0-blue?style=flat-square)](https://github.com/Lyr3x/Roode/releases/tag/1.6.0)
 [![Build](https://img.shields.io/github/actions/workflow/status/Lyr3x/Roode/ci.yml?style=flat-square)](https://github.com/Lyr3x/Roode/blob/master/.github/workflows/ci.yml)
 
 [![Roode community](https://img.shields.io/discord/879407995837087804.svg?label=Discord&logo=Discord&colorB=7289da&style=for-the-badge)](https://discord.gg/hU9SvSXMHs)

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -21,7 +21,7 @@ namespace esphome {
 namespace roode {
 #define NOBODY 0
 #define SOMEONE 1
-#define VERSION "1.5.1"
+#define VERSION "1.6.0"
 static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
 static const char *const CALIBRATION = "Sensor Calibration";


### PR DESCRIPTION
## Summary
- update version string in `roode.h`
- update README release badge
- expand 1.6.0 changelog notes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68772a5bbb148330b7f7f83f88504664