### PR TITLE
Fix missing closing brace in roode.cpp

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -746,6 +746,7 @@ void Roode::update_status_text(const std::string &status) {
     status_text_sensor->publish_state(status);
     last_status_text_ = status;
   }
+}
 
 void Roode::restart_sensor() {
   distanceSensor->restart();


### PR DESCRIPTION
## Summary
- correct missing closing bracket in Roode::update_status_text

## Testing
- `g++ -fsyntax-only -I/tmp components/roode/roode.cpp -std=c++17` *(fails: esphome/components/binary_sensor/binary_sensor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877b36a1958833088cbed61d052bc38