### PR TITLE
Restore VL53L1X restart implementation

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -746,6 +746,7 @@ void Roode::update_status_text(const std::string &status) {
     status_text_sensor->publish_state(status);
     last_status_text_ = status;
   }
+}
 
 void Roode::restart_sensor() {
   distanceSensor->restart();

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -451,6 +451,27 @@ bool VL53L1X::validate_interrupt() {
   return ok;
 }
 
+void VL53L1X::restart() {
+  if (this->xshut_pin.has_value()) {
+    this->xshut_pin.value()->digital_write(false);
+    roode::Roode::log_event("xshut_pulse_off_sensor_" + std::to_string(sensor_id_));
+    roode::Roode::log_event("xshut_pulse_off");
+    ESP_LOGW(TAG, "XShut pin set LOW - restarting sensor");
+    delay(100);
+    this->xshut_pin.value()->digital_write(true);
+    roode::Roode::log_event("xshut_reinitialize_sensor_" + std::to_string(sensor_id_));
+    roode::Roode::log_event("xshut_reinitialize");
+    ESP_LOGD(TAG, "XShut pin set HIGH - restart complete");
+    this->wait_for_boot();
+    roode::Roode::log_event("sensor_" + std::to_string(sensor_id_) + ".recovered_via_xshut");
+    roode::Roode::log_event("sensor.recovered_via_xshut");
+    recovery_count_++;
+  } else {
+    ESP_LOGW(TAG, "Restarting sensor without XSHUT pin");
+    this->init();
+  }
+}
+
 void VL53L1X::soft_reset() {
 
   if (this->xshut_pin.has_value()) {


### PR DESCRIPTION
## Summary
- re-add `restart()` implementation for VL53L1X sensor
- previous fix for missing brace in `update_status_text`

## Testing
- `g++ -fsyntax-only -I/tmp components/roode/roode.cpp -std=c++17` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6877b36a1958833088cbed61d052bc38