### PR TITLE
Add HA sunrise fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ reflections cause false triggers.
 | `roode.filter_mode` & `roode.filter_window` | Optional | `min` / `5` | How samples are combined and window size | Noisy environment | Use `median`/`percentile10` with larger windows | `filter_mode: min`<br>`filter_window: 5` | `filter_mode: percentile10`<br>`filter_window: 9` |
 | `roode.log_fallback_events` | Optional | `false` | Record INT/XSHUT fallback events | Debugging unexpected counts | Enable while testing | `log_fallback_events: false` | `log_fallback_events: true` |
 | `roode.force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | `force_single_core: false` | `force_single_core: true` |
+| `roode.sun_entity_id` | Optional | `sun.sun` | Use Home Assistant sun entity for sunrise/sunset | No coordinates available | Change if using a custom sun entity | *(not set)* | `sun_entity_id: sun.custom` |
 | `roode.zones.invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | `zones: { invert: false }` | `zones: { invert: true }` |
 | `roode.zones.entry/exit` | Optional | none | Per-zone ROI and thresholds | Uneven hallway or obstacles | Tweak each zone separately as needed | *(not set)* | `zones:`<br>`  exit:`<br>`    roi:`<br>`      height: 8` |
 
@@ -590,6 +591,7 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | Persistent calibration | Calibration data can persist in flash across reboots |
 | Scheduled recalibration | Periodically or temperature-based recalibration of thresholds |
 | Ambient light suppression | Learns lux levels with optional sunrise prediction |
+| Home Assistant sun fallback | Uses `sun.sun` when latitude/longitude omitted |
 | Dual-core tasking | Keeps polling responsive on ESP32 with automatic retry/fallback |
 | Filtering options | Median/percentile filters smooth jitter with adjustable window |
 | FSM timeouts | Resets the state machine when a transition stalls |

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -61,6 +61,7 @@ CONF_LUX_SAMPLE_INTERVAL = "lux_sample_interval"
 CONF_USE_SUNRISE_PREDICTION = "use_sunrise_prediction"
 CONF_LATITUDE = "latitude"
 CONF_LONGITUDE = "longitude"
+CONF_SUN_ENTITY_ID = "sun_entity_id"
 CONF_ALPHA = "alpha"
 CONF_BASE_MULTIPLIER = "base_multiplier"
 CONF_MAX_MULTIPLIER = "max_multiplier"
@@ -109,21 +110,28 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_ROI, default={}): ROI_SCHEMA,
         cv.Optional(CONF_DETECTION_THRESHOLDS, default={}): THRESHOLDS_SCHEMA,
         cv.Optional(CONF_CALIBRATION_PERSISTENCE, default=False): cv.boolean,
-        cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
+        cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(
+            FILTER_MODES, upper=False
+        ),
         cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_LOG_FALLBACK, default=False): cv.boolean,
         cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
         # Scheduled recalibration options
-        cv.Optional(CONF_AUTO_RECALIBRATE_INTERVAL, default="6h"): cv.positive_time_period,
+        cv.Optional(
+            CONF_AUTO_RECALIBRATE_INTERVAL, default="6h"
+        ): cv.positive_time_period,
         cv.Optional(CONF_RECALIBRATE_ON_TEMP_CHANGE, default=False): cv.boolean,
         cv.Optional(CONF_MAX_TEMP_DELTA_FOR_RECALIB, default=8): cv.int_,
-        cv.Optional(CONF_RECALIBRATE_COOLDOWN, default="30min"): cv.positive_time_period,
+        cv.Optional(
+            CONF_RECALIBRATE_COOLDOWN, default="30min"
+        ): cv.positive_time_period,
         cv.Optional(CONF_USE_LIGHT_SENSOR, default=False): cv.boolean,
         cv.Optional(CONF_LUX_LEARNING_WINDOW, default="24h"): cv.positive_time_period,
         cv.Optional(CONF_LUX_SAMPLE_INTERVAL, default="1min"): cv.positive_time_period,
         cv.Optional(CONF_USE_SUNRISE_PREDICTION, default=False): cv.boolean,
         cv.Optional(CONF_LATITUDE): cv.float_,
         cv.Optional(CONF_LONGITUDE): cv.float_,
+        cv.Optional(CONF_SUN_ENTITY_ID, default="sun.sun"): cv.string,
         cv.Optional(CONF_ALPHA, default=0.5): cv.float_,
         cv.Optional(CONF_BASE_MULTIPLIER, default=1.0): cv.float_,
         cv.Optional(CONF_MAX_MULTIPLIER, default=4.0): cv.float_,
@@ -163,39 +171,35 @@ async def to_code(config: Dict):
             config[CONF_AUTO_RECALIBRATE_INTERVAL].total_seconds
         )
     )
-    cg.add(roode.set_recalibrate_on_temp_change(config[CONF_RECALIBRATE_ON_TEMP_CHANGE]))
-    cg.add(roode.set_max_temp_delta_for_recalib(config[CONF_MAX_TEMP_DELTA_FOR_RECALIB]))
     cg.add(
-        roode.set_recalibrate_cooldown(
-            config[CONF_RECALIBRATE_COOLDOWN].total_seconds
-        )
+        roode.set_recalibrate_on_temp_change(config[CONF_RECALIBRATE_ON_TEMP_CHANGE])
+    )
+    cg.add(
+        roode.set_max_temp_delta_for_recalib(config[CONF_MAX_TEMP_DELTA_FOR_RECALIB])
+    )
+    cg.add(
+        roode.set_recalibrate_cooldown(config[CONF_RECALIBRATE_COOLDOWN].total_seconds)
     )
     cg.add(roode.set_use_light_sensor(config[CONF_USE_LIGHT_SENSOR]))
     cg.add(
-        roode.set_lux_learning_window(
-            config[CONF_LUX_LEARNING_WINDOW].total_seconds
-        )
+        roode.set_lux_learning_window(config[CONF_LUX_LEARNING_WINDOW].total_seconds)
     )
     cg.add(
-        roode.set_lux_sample_interval(
-            config[CONF_LUX_SAMPLE_INTERVAL].total_seconds
-        )
+        roode.set_lux_sample_interval(config[CONF_LUX_SAMPLE_INTERVAL].total_seconds)
     )
     cg.add(roode.set_use_sunrise_prediction(config[CONF_USE_SUNRISE_PREDICTION]))
     if CONF_LATITUDE in config:
         cg.add(roode.set_latitude(config[CONF_LATITUDE]))
     if CONF_LONGITUDE in config:
         cg.add(roode.set_longitude(config[CONF_LONGITUDE]))
+    if CONF_SUN_ENTITY_ID in config:
+        cg.add(roode.set_sun_entity_id(config[CONF_SUN_ENTITY_ID]))
     cg.add(roode.set_alpha(config[CONF_ALPHA]))
     cg.add(roode.set_base_multiplier(config[CONF_BASE_MULTIPLIER]))
     cg.add(roode.set_max_multiplier(config[CONF_MAX_MULTIPLIER]))
     cg.add(roode.set_time_multiplier(config[CONF_TIME_MULTIPLIER]))
     cg.add(roode.set_combined_multiplier(config[CONF_COMBINED_MULTIPLIER]))
-    cg.add(
-        roode.set_suppression_window(
-            config[CONF_SUPPRESSION_WINDOW].total_seconds
-        )
-    )
+    cg.add(roode.set_suppression_window(config[CONF_SUPPRESSION_WINDOW].total_seconds))
     if CONF_IDLE_RECALIB_INTERVAL in config:
         cg.add(
             roode.set_idle_recalib_interval(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -6,6 +6,9 @@
 #include <algorithm>
 #include <ctime>
 #include <cmath>
+#ifdef USE_API
+#include "esphome/components/api/api_server.h"
+#endif
 
 namespace esphome {
 namespace roode {
@@ -144,6 +147,36 @@ static int calc_sun_time(const struct tm &date, float lat, float lon, bool sunri
   while (UT >= 24)
     UT -= 24.0f;
   return static_cast<int>(UT * 3600.0f);
+}
+
+static bool parse_ha_time(const std::string &value, int &out_sec) {
+  int yy, MM, dd, hh, mm, ss;
+  if (sscanf(value.c_str(), "%d-%d-%dT%d:%d:%d", &yy, &MM, &dd, &hh, &mm, &ss) < 6)
+    return false;
+  out_sec = hh * 3600 + mm * 60 + ss;
+  return true;
+}
+
+bool Roode::fetch_sun_times_from_ha(int &rise, int &set) {
+#ifdef USE_API
+  if (sun_entity_id_.empty())
+    return false;
+  auto *api = api::global_api_server;
+  if (api == nullptr)
+    return false;
+  auto state = api->get_state(sun_entity_id_);
+  if (!state.has_value())
+    return false;
+  std::string sunrise = state->attributes["next_rising"].as<std::string>();
+  std::string sunset = state->attributes["next_setting"].as<std::string>();
+  if (!parse_ha_time(sunrise, rise) || !parse_ha_time(sunset, set))
+    return false;
+  return true;
+#else
+  (void) rise;
+  (void) set;
+  return false;
+#endif
 }
 
 Roode::~Roode() {
@@ -669,7 +702,7 @@ void Roode::update_sun_times() {
   if (latitude_ != 0.0f || longitude_ != 0.0f) {
     sunrise_sec_ = calc_sun_time(tm_time, latitude_, longitude_, true);
     sunset_sec_ = calc_sun_time(tm_time, latitude_, longitude_, false);
-  } else {
+  } else if (!fetch_sun_times_from_ha(sunrise_sec_, sunset_sec_)) {
     sunrise_sec_ = 21600;
     sunset_sec_ = 64800;
   }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -110,9 +110,7 @@ class Roode : public PollingComponent {
   void set_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
   void set_sensor_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
   void set_interrupt_status_sensor(sensor::Sensor *sens) { interrupt_status_sensor = sens; }
-  void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) {
-    enabled_features_sensor = sensor_;
-  }
+  void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }
   void set_manual_adjustment_sensor(sensor::Sensor *sens) { manual_adjustment_sensor = sens; }
   void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
   void set_force_single_core(bool val) { force_single_core_ = val; }
@@ -128,6 +126,7 @@ class Roode : public PollingComponent {
   void set_use_sunrise_prediction(bool val) { use_sunrise_prediction_ = val; }
   void set_latitude(float val) { latitude_ = val; }
   void set_longitude(float val) { longitude_ = val; }
+  void set_sun_entity_id(const std::string &id) { sun_entity_id_ = id; }
   void set_alpha(float val) { alpha_ = val; }
   void set_base_multiplier(float val) { base_multiplier_ = val; }
   void set_max_multiplier(float val) { max_multiplier_ = val; }
@@ -161,6 +160,7 @@ class Roode : public PollingComponent {
   bool should_suppress_event();
   void adjust_filtering();
   void update_sun_times();
+  bool fetch_sun_times_from_ha(int &rise, int &set);
   bool validate_lux_sensor();
   bool validate_temperature_sensor();
   void check_context_calibration();
@@ -195,7 +195,6 @@ class Roode : public PollingComponent {
   text_sensor::TextSensor *enabled_features_sensor{nullptr};
   sensor::Sensor *manual_adjustment_sensor{nullptr};
   sensor::Sensor *interrupt_status_sensor{nullptr};
-
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;
@@ -243,6 +242,7 @@ class Roode : public PollingComponent {
   bool use_sunrise_prediction_{false};
   float latitude_{0};
   float longitude_{0};
+  std::string sun_entity_id_{"sun.sun"};
   float alpha_{0.5f};
   float base_multiplier_{1.0f};
   float max_multiplier_{4.0f};


### PR DESCRIPTION
## Summary
- fetch sunrise/sunset from Home Assistant when coordinates are not set
- expose `sun_entity_id` option in the YAML config
- document Home Assistant sunrise fallback feature

## Testing
- `pip install esphome` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6878770a592c833097e47a892881d8fa