### PR TITLE
Improve feature sensor info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.0
 - Scheduled recalibration based on time or temperature changes
 - Ambient light learning with optional sunrise prediction
+- Feature sensor shows last and next calibration, buffer fill and next sun event
 
 ## 1.6.0
 - Auto restart sensors via XSHUT with multiplexing support

--- a/README.md
+++ b/README.md
@@ -616,8 +616,10 @@ interrupt and polling mode, and manual adjustments to the people count.
 
 The `enabled_features` text sensor summarizes which runtime features are active.
 Typical values include `dual_core` or `single_core`, `xshut` or `no_xshut`, and
-`interrupt` or `polling`. This helps verify that the hardware pins and options
-are detected correctly.
+`interrupt` or `polling`. Additional fields show the last calibration time, the
+next scheduled calibration, the fill level of the ambient light buffer and the
+upcoming sunrise or sunset when tracking is enabled. This helps verify that the
+hardware pins and options are detected correctly.
 
 ### Diagnostic sensors
 


### PR DESCRIPTION
## Summary
- show month/day time when formatting feature timestamps
- report buffer percent and sun event in feature sensor
- document new feature text sensor fields
- note feature sensor update in changelog

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f1c65ce88330a2db0c96a3b4af08