### PR TITLE
Improve feature sensor info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.7.0
 - Scheduled recalibration based on time or temperature changes
 - Ambient light learning with optional sunrise prediction
+- Feature sensor shows last and next calibration, buffer fill and next sun event
 
 ## 1.6.0
 - Auto restart sensors via XSHUT with multiplexing support

--- a/README.md
+++ b/README.md
@@ -448,12 +448,13 @@ roode:
   temperature_sensor: temperature
 ```
 The features string lists items as `name:value` pairs separated by new lines.
-The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`,
-`cpu_cores`, `ram`, `flash`, `calibration_value` and `calibration`.
-Memory values are printed with **KB**, **MB** or **GB** units. Calibration time
-uses the device clock in `h:MMAM/PM` format or displays `unknown` if the clock
-has not been initialised. When the device falls back to UTC because no time
-zone was provided by Home Assistant, the time is followed by `(UTC)`.
+Fields include `xshut`, `refresh`, `cpu_mode`, `cpu`,
+`cpu_cores`, `ram`, `flash`, `calibration_value`, `calibration` and
+`schedule_calibration`. When ambient light learning is enabled you will also see
+`buffer` and `sun_event`. Memory values are printed with **KB**, **MB** or **GB**
+units. Calibration time uses the device clock in `M/D h:MMAM/PM` format or
+displays `unknown` if the clock has not been initialised. When the device falls
+back to UTC because no time zone was provided, the time is followed by `UTC`.
 
 Example output:
 
@@ -467,6 +468,9 @@ ram:309KB
 flash:16MB
 calibration_value:1399
 calibration:6:01PM (UTC)
+schedule_calibration:01/01 12:06AM UTC
+buffer:80%
+sun_event:sunset 01/01 05:00PM UTC
 ```
 
 ### Threshold distance
@@ -616,8 +620,10 @@ interrupt and polling mode, and manual adjustments to the people count.
 
 The `enabled_features` text sensor summarizes which runtime features are active.
 Typical values include `dual_core` or `single_core`, `xshut` or `no_xshut`, and
-`interrupt` or `polling`. This helps verify that the hardware pins and options
-are detected correctly.
+`interrupt` or `polling`. Additional fields show the last calibration time, the
+next scheduled calibration, the fill level of the ambient light buffer and the
+upcoming sunrise or sunset when tracking is enabled. This helps verify that the
+hardware pins and options are detected correctly.
 
 ### Diagnostic sensors
 

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -549,8 +549,9 @@ void Roode::recalibration() { perform_recalibration(true); }
 void Roode::perform_recalibration(bool manual) {
   calibrate_zones();
   last_recalibrate_ts_ = static_cast<uint32_t>(time(nullptr));
-  if (!manual)
-    last_auto_recalibrate_ts_ = last_recalibrate_ts_;
+  // Keep the next scheduled calibration in sync with the most recent
+  // recalibration time so the feature sensor never reports an unknown value.
+  last_auto_recalibrate_ts_ = last_recalibrate_ts_;
   if (manual)
     log_event("manual_recalibrate_triggered");
 }
@@ -1004,12 +1005,15 @@ void Roode::publish_feature_list() {
         return std::string("unknown");
     }
 
-    char buf[16];
+    char buf[32];
+    char tmp[16];
     int hour = tm_time.tm_hour % 12;
     if (hour == 0)
       hour = 12;
-    snprintf(buf, sizeof(buf), "%d:%02d%cM%s", hour, tm_time.tm_min,
-             tm_time.tm_hour >= 12 ? 'P' : 'A', use_utc ? " (UTC)" : "");
+    snprintf(tmp, sizeof(tmp), "%d:%02d%cM", hour, tm_time.tm_min,
+             tm_time.tm_hour >= 12 ? 'P' : 'A');
+    snprintf(buf, sizeof(buf), "%02d/%02d %s%s", tm_time.tm_mon + 1,
+             tm_time.tm_mday, tmp, use_utc ? " UTC" : "");
     return std::string(buf);
   };
 
@@ -1053,6 +1057,40 @@ void Roode::publish_feature_list() {
     features.push_back({"schedule_calibration", fmt_time(next_cal)});
   } else {
     features.push_back({"schedule_calibration", "disabled"});
+  }
+
+  if (lux_enabled) {
+    size_t total = lux_learning_window_sec_ / lux_sample_interval_sec_;
+    float pct = 0.0f;
+    if (total > 0)
+      pct = ((float) lux_samples_.size() / (float) total) * 100.0f;
+    char buf2[8];
+    snprintf(buf2, sizeof(buf2), "%.0f%%", pct);
+    features.push_back({"buffer", buf2});
+  } else {
+    features.push_back({"buffer", "none"});
+  }
+
+  if (use_sunrise_prediction_) {
+    time_t now_t = time(nullptr);
+    struct tm tm_time;
+    localtime_r(&now_t, &tm_time);
+    int sec_of_day = tm_time.tm_hour * 3600 + tm_time.tm_min * 60 + tm_time.tm_sec;
+    int event_sec;
+    const char *event_name;
+    if (sec_of_day >= sunrise_sec_ && sec_of_day < sunset_sec_) {
+      event_sec = sunset_sec_;
+      event_name = "sunset";
+    } else {
+      event_sec = sunrise_sec_;
+      event_name = "sunrise";
+      if (sec_of_day >= sunset_sec_)
+        now_t += 86400;
+    }
+    uint32_t event_epoch = (uint32_t) (now_t - sec_of_day + event_sec);
+    features.push_back({"sun_event", std::string(event_name) + " " + fmt_time(event_epoch)});
+  } else {
+    features.push_back({"sun_event", "none"});
   }
 
   std::string feature_list;


### PR DESCRIPTION
## Summary
- show month/day time when formatting feature timestamps
- report buffer percent and sun event in feature sensor
- document new feature text sensor fields
- note feature sensor update in changelog
- sync next scheduled calibration after manual recalibration to prevent unknown value

## Testing
- `pio --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878f1c65ce88330a2db0c96a3b4af08