### PR TITLE
Add multi-sensor selection helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ reflections cause false triggers.
 | [peopleCounter8266.yaml](peopleCounter8266.yaml) | Minimal setup for ESP8266 |
 | [peopleCounter8266Dev.yaml](peopleCounter8266Dev.yaml) | Most advanced ESP8266 configuration |
 | [extra_sensors_example.yaml](extra_sensors_example.yaml) | Additional diagnostic sensors |
+| [sensor_multiselect_input.yaml](sensor_multiselect_input.yaml) | Home Assistant helper to pick multiple sensors |
 
 ### Sensors
 

--- a/sensor_multiselect_input.yaml
+++ b/sensor_multiselect_input.yaml
@@ -1,0 +1,29 @@
+input_select:
+  roode_sensor_picker:
+    name: Roode Sensors
+    options:
+      - people_counter
+      - presence_sensor
+      - sensor_xshut_state
+      - distance_entry
+      - distance_exit
+      - max_threshold_entry
+      - max_threshold_exit
+      - min_threshold_entry
+      - min_threshold_exit
+      - roi_height_entry
+      - roi_width_entry
+      - roi_height_exit
+      - roi_width_exit
+      - loop_time
+      - cpu_usage
+      - ram_free
+      - flash_free
+      - sensor_status
+      - interrupt_status
+      - manual_adjustment_count
+      - version
+      - entry_exit_event
+      - sensor_status_text
+      - enabled_features
+


### PR DESCRIPTION
## Summary
- add example input_select with all sensors
- link new YAML example from README

## Testing
- `black --check README.md sensor_multiselect_input.yaml` *(fails: Cannot parse)*

------
https://chatgpt.com/codex/tasks/task_e_687d4cc09bb48330b91091a24852f822