### PR TITLE
Add demo dashboard with custom card

### DIFF
--- a/dashboard/demo_view.yaml
+++ b/dashboard/demo_view.yaml
@@ -1,0 +1,14 @@
+# Demo view using SmartViewCard
+views:
+  - title: Demo
+    path: demo
+    cards:
+      - type: custom:smart-view-card
+        content: |
+          <h2>Demo Content</h2>
+          <p>This custom card scrolls vertically inside the card area.</p>
+          <p>Add more paragraphs to test scrolling.</p>
+          <p>Line 4</p>
+          <p>Line 5</p>
+          <p>Line 6</p>
+

--- a/dashboard/smartview-dashboard-scripts.js
+++ b/dashboard/smartview-dashboard-scripts.js
@@ -1,0 +1,46 @@
+class SmartViewCard extends HTMLElement {
+  setConfig(config) {
+    this._config = config;
+    if (this.shadowRoot) {
+      this._update();
+      return;
+    }
+    this.attachShadow({ mode: 'open' });
+    const style = document.createElement('style');
+    style.textContent = `
+      :host {
+        display: block;
+        overflow: hidden;
+        height: 100%;
+        width: 100%;
+      }
+      .container {
+        box-sizing: border-box;
+        height: 100%;
+        width: 100%;
+        overflow-y: auto;
+        overflow-x: hidden;
+      }
+    `;
+    this._container = document.createElement('div');
+    this._container.classList.add('container');
+    this.shadowRoot.append(style, this._container);
+    this._update();
+  }
+
+  set hass(hass) {
+    this._hass = hass;
+    if (!this._config || !this.shadowRoot) return;
+  }
+
+  getCardSize() {
+    return 3;
+  }
+
+  _update() {
+    if (!this._container) return;
+    const content = this._config.content || '';
+    this._container.innerHTML = content;
+  }
+}
+customElements.define('smart-view-card', SmartViewCard);

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -23,3 +23,6 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
     data:
       newCount: "{{ states('input_number.set_people32') | int }}"
 ```
+
+## Dashboard Demo
+Add the demo view to your dashboard by including `dashboard/demo_view.yaml` in your Lovelace configuration. Ensure `smartview-dashboard-scripts.js` is served from `/local/smartview-dashboard-scripts.js` and referenced in your resources.


### PR DESCRIPTION
## Summary
- add SmartView custom card JS in `dashboard/smartview-dashboard-scripts.js`
- add example view `dashboard/demo_view.yaml`
- document the demo dashboard in `home_assistant.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687ebaf1cf38833086b6616968df688b