### PR TITLE
Auto-create configuration text sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
 - Interrupt mode gracefully falls back to polling and logs the reason
 - Colored logs for easier troubleshooting
 
+## 1.6.1
+- Automatically create `sensor_name`, `enabled_features` and
+  `optional_sensors` text sensors with `entity_category: config`
+  to simplify configuration. Default names include the Roode ID to avoid
+  duplicates when several sensors are present
+- These sensors are added even when the `text_sensor` block is omitted and can
+  be renamed by defining a single `platform: roode` block
+- Validation now errors if multiple `platform: roode` text sensor blocks use
+  the same id, preventing duplicate entity names
+- Fix default text sensor names when the Roode id is omitted
+- Apply defaults before validation so unique names are always generated
+
 ## 1.5.1
 - Add diagnostic sensors reporting loop time, CPU usage, and RAM and flash usage percentages
 

--- a/README.md
+++ b/README.md
@@ -415,16 +415,24 @@ text_sensor:
   - platform: roode
     version:
       name: $friendly_name version
-  - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
-  - platform: roode
     sensor_status:
       name: $friendly_name sensor status text
-  - platform: roode
-    enabled_features:
-      name: $friendly_name enabled features
-      ## This sensor is a text_sensor that lists all enabled features
+  # The sensor_name, enabled_features and optional_sensors text sensors are
+  # created automatically by the Roode component with `entity_category: config`,
+  # even if this `text_sensor` section is omitted entirely. Their default names
+  # include the Roode ID (when `roode_id` is set) so multiple sensors don't
+  # clash. Adding a `platform: roode` block lets you rename them if desired.
+  # Only one such block is allowed per Roode id; otherwise ESPHome will report
+  # duplicate entity names.
+  # To override the default names you can specify them here:
+  #   sensor_name:
+  #     name: My Sensor Name
+  #   enabled_features:
+  #     name: My Enabled Features
+  #   optional_sensors:
+  #     name: My Optional Sensors
 ```
 The features string lists items as `name:value` pairs separated by new lines.
 The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`,
@@ -475,6 +483,8 @@ calibration:6:01PM
 | `entry_exit_event` | text_sensor | Last entry or exit direction |
 | `sensor_status` (text) | text_sensor | "ok", "timeout", "reinitializing", "error" or "offline" |
 | `enabled_features` | text_sensor | List of active runtime features |
+| `sensor_name` | text_sensor | Name of the device reported by ESPHome |
+| `optional_sensors` | text_sensor | Runtime list of optional sensors |
 
 
 ### Threshold distance
@@ -622,12 +632,21 @@ in the `roode:` section to include interrupt fallbacks and XSHUT recovery
 details. Event logs cover power cycles of the sensor, automatic changes between
 interrupt and polling mode, and manual adjustments to the people count.
 
-### Feature text sensor
+### Configuration text sensors
 
-The `enabled_features` text sensor summarizes which runtime features are active.
-Typical values include `dual_core` or `single_core`, `xshut` or `no_xshut`, and
-`interrupt` or `polling`. This helps verify that the hardware pins and options
-are detected correctly.
+The plugin automatically exposes three text sensors with `entity_category: config`.
+They are created even if the `text_sensor` block is omitted. When `roode_id` is set
+their default names include the Roode ID so multiple sensors can exist in one
+device without clashes. Otherwise generic names are used:
+
+- `sensor_name` publishes the device's name.
+- `enabled_features` lists runtime options like `dual_core` vs `single_core`,
+  `xshut` vs `no_xshut` and `interrupt` vs `polling`.
+- `optional_sensors` shows which extra sensors are enabled at runtime.
+
+These help verify that the hardware pins and options are detected correctly. When
+adding text sensors in YAML, use a single `platform: roode` entry so these
+auto-generated sensors only appear once or rename them as needed.
 
 ### Diagnostic sensors
 
@@ -637,8 +656,9 @@ Optional sensors provide insight into Roode's operation:
 - `sensor_status` and `interrupt_status` show the current hardware state. The
   status sensor reports `ok`, `timeout`, `reinitializing`, `error` or `offline`
   so automations can react to issues.
-- `version`, `entry_exit_event` and `enabled_features` provide diagnostic text,
-  and a text-sensor `sensor_status` exposes the same status string.
+- `version`, `entry_exit_event`, `sensor_name`, `enabled_features` and
+  `optional_sensors` provide diagnostic text, and a text-sensor `sensor_status`
+  exposes the same status string.
 - ROI size and threshold sensors allow live tuning of each zone.
 - `manual_adjustment_count` records people-count corrections.
 - The sensor automatically restarts if polling stops for the configured `restart_timeout`

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -7,7 +7,14 @@ from esphome.const import (
     CONF_INVERT,
     CONF_SENSOR,
     CONF_WIDTH,
+    CONF_NAME,
+    CONF_ICON,
+    CONF_ENTITY_CATEGORY,
+    ENTITY_CATEGORY_CONFIG,
 )
+from esphome import core
+from esphome.components import text_sensor
+import roode.text_sensor as roode_ts
 from ..vl53l1x import distance_as_mm, NullableSchema, VL53L1X
 
 DEPENDENCIES = ["vl53l1x"]
@@ -125,6 +132,25 @@ async def to_code(config: Dict):
     cg.add(roode.set_invert_direction(config[CONF_ZONES][CONF_INVERT]))
     setup_zone(CONF_ENTRY_ZONE, config, roode)
     setup_zone(CONF_EXIT_ZONE, config, roode)
+
+    # Auto-create configuration text sensors if they weren't explicitly added via
+    # a text_sensor block. When multiple Roode components are present each name
+    # includes the component ID to avoid duplicates.
+    rid = str(config[CONF_ID])
+    suffix = f" {rid}" if rid else ""
+    defined = roode_ts.configured_sensors.get(rid, set())
+    defaults = {
+        roode_ts.SENSOR_NAME: ("mdi:identifier", f"Roode Sensor Name{suffix}"),
+        roode_ts.FEATURES: ("mdi:cog", f"Roode Enabled Features{suffix}"),
+        roode_ts.OPTIONAL_SENSORS: ("mdi:format-list-checks", f"Roode Optional Sensors{suffix}"),
+    }
+    for key, (icon, name) in defaults.items():
+        if key in defined:
+            continue
+        sensor_id = core.ID(None, type=text_sensor.TextSensor)
+        conf = {CONF_ID: sensor_id, CONF_NAME: name, CONF_ICON: icon, CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_CONFIG}
+        sens = await text_sensor.new_text_sensor(conf)
+        cg.add(getattr(roode, f"set_{key}_text_sensor")(sens))
 
 
 def setup_zone(name: str, config: Dict, roode: cg.Pvariable):

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -108,6 +108,7 @@ void Roode::log_event(const std::string &msg) {
     if (msg == "dual_core_success" || msg == "fallback_single_core" || msg == "force_single_core" ||
         msg == "interrupt_fallback_polling" || msg == "interrupt_recovered") {
       instance_->publish_feature_list();
+      instance_->publish_optional_sensors();
     }
   }
 }
@@ -128,6 +129,9 @@ void Roode::setup() {
   ESP_LOGI(SETUP, "Booting Roode %s", VERSION);
   if (version_sensor != nullptr) {
     version_sensor->publish_state(VERSION);
+  }
+  if (sensor_name_sensor != nullptr) {
+    sensor_name_sensor->publish_state(App.get_name());
   }
   ESP_LOGI(SETUP, "Using sampling with sampling size: %d", samples);
 
@@ -243,6 +247,7 @@ void Roode::setup() {
     expected_counter_ = people_counter->state;
 
   publish_feature_list();
+  publish_optional_sensors();
   update_status_text("ok");
 }
 
@@ -298,8 +303,7 @@ void Roode::loop() {
   } else {
     invalid_read_count_ = 0;
   }
-  if (invalid_read_count_ > invalid_distance_limit_ &&
-      (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
+  if (invalid_read_count_ > invalid_distance_limit_ && (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
     ESP_LOGW(TAG, "Consecutive invalid distances, restarting...");
     restart_sensor();
   }
@@ -526,6 +530,7 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   publish_sensor_configuration(entry, exit, true);
   publish_sensor_configuration(entry, exit, false);
   publish_feature_list();
+  publish_optional_sensors();
 }
 
 void Roode::apply_cpu_optimizations(float cpu) {
@@ -643,6 +648,7 @@ void Roode::calibrate_zones() {
   }
   ESP_LOGI(SETUP, "Finished calibrating sensor zones");
   publish_feature_list();
+  publish_optional_sensors();
 }
 
 void Roode::calibrateDistance() {
@@ -750,6 +756,30 @@ void Roode::publish_feature_list() {
   log_event(std::string("features_enabled: ") + feature_list);
 }
 
+void Roode::publish_optional_sensors() {
+  std::vector<std::string> sensors;
+  if (loop_time_sensor != nullptr)
+    sensors.push_back("loop_time");
+  if (cpu_usage_sensor != nullptr)
+    sensors.push_back("cpu_usage");
+  if (ram_free_sensor != nullptr)
+    sensors.push_back("ram_free");
+  if (flash_free_sensor != nullptr)
+    sensors.push_back("flash_free");
+  if (interrupt_status_sensor != nullptr)
+    sensors.push_back("interrupt_status");
+  if (manual_adjustment_sensor != nullptr)
+    sensors.push_back("manual_adjustment_count");
+
+  std::string sensor_list;
+  for (size_t i = 0; i < sensors.size(); ++i) {
+    sensor_list += sensors[i];
+    if (i + 1 < sensors.size())
+      sensor_list += "\n";
+  }
+  if (optional_sensors_sensor != nullptr)
+    optional_sensors_sensor->publish_state(sensor_list);
+}
 
 void Roode::update_status_text(const std::string &status) {
   if (status_text_sensor != nullptr && status != last_status_text_) {
@@ -769,8 +799,7 @@ void Roode::sensor_task(void *param) {
   for (;;) {
     self->use_sensor_task_ = true;
     uint32_t now = millis();
-    if (self->last_loop_update_ts_ != 0 &&
-        (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
+    if (self->last_loop_update_ts_ != 0 && (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
         (now - self->last_sensor_restart_ts_ > self->restart_timeout_ms_)) {
       ESP_LOGW(TAG, "Sensor unresponsive >%ds, restarting...", self->restart_timeout_ms_ / 1000);
       self->restart_sensor();

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -111,6 +111,8 @@ class Roode : public PollingComponent {
   void set_interrupt_status_sensor(sensor::Sensor *sens) { interrupt_status_sensor = sens; }
   void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }
   void set_sensor_status_text_sensor(text_sensor::TextSensor *sensor_) { status_text_sensor = sensor_; }
+  void set_sensor_name_text_sensor(text_sensor::TextSensor *sensor_) { sensor_name_sensor = sensor_; }
+  void set_optional_sensors_text_sensor(text_sensor::TextSensor *sensor_) { optional_sensors_sensor = sensor_; }
   void set_manual_adjustment_sensor(sensor::Sensor *sens) { manual_adjustment_sensor = sens; }
   void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
   void set_force_single_core(bool val) { force_single_core_ = val; }
@@ -165,6 +167,8 @@ class Roode : public PollingComponent {
   text_sensor::TextSensor *entry_exit_event_sensor{nullptr};
   text_sensor::TextSensor *enabled_features_sensor{nullptr};
   text_sensor::TextSensor *status_text_sensor{nullptr};
+  text_sensor::TextSensor *sensor_name_sensor{nullptr};
+  text_sensor::TextSensor *optional_sensors_sensor{nullptr};
   sensor::Sensor *manual_adjustment_sensor{nullptr};
   sensor::Sensor *interrupt_status_sensor{nullptr};
 
@@ -212,6 +216,7 @@ class Roode : public PollingComponent {
   void calibrateDistance();
   void calibrate_zones();
   void publish_feature_list();
+  void publish_optional_sensors();
   const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
   void publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax);
   void updateCounter(int delta);

--- a/components/roode/text_sensor.py
+++ b/components/roode/text_sensor.py
@@ -6,6 +6,7 @@ from esphome.const import (
     CONF_ICON,
     CONF_ENTITY_CATEGORY,
     ENTITY_CATEGORY_DIAGNOSTIC,
+    ENTITY_CATEGORY_CONFIG,
 )
 from . import Roode, CONF_ROODE_ID
 
@@ -15,49 +16,102 @@ VERSION = "version"
 ENTRY_EXIT_EVENT = "entry_exit_event"
 STATUS = "sensor_status"
 FEATURES = "enabled_features"
+SENSOR_NAME = "sensor_name"
+OPTIONAL_SENSORS = "optional_sensors"
 
-TYPES = [VERSION, ENTRY_EXIT_EVENT, STATUS, FEATURES]
+TYPES = [VERSION, ENTRY_EXIT_EVENT, STATUS, FEATURES, SENSOR_NAME, OPTIONAL_SENSORS]
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
-        cv.Optional(VERSION): text_sensor.text_sensor_schema().extend(
-            {
-                cv.Optional(CONF_ICON, default="mdi:git"): cv.icon,
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(
-                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
-                ): cv.entity_category,
-            }
-        ),
-        cv.Optional(ENTRY_EXIT_EVENT): text_sensor.text_sensor_schema().extend(
-            {
-                cv.Optional(CONF_ICON, default="mdi:sign-direction"): cv.icon,
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(
-                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
-                ): cv.entity_category,
-            }
-        ),
-        cv.Optional(STATUS): text_sensor.text_sensor_schema().extend(
-            {
-                cv.Optional(CONF_ICON, default="mdi:check-circle"): cv.icon,
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(
-                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
-                ): cv.entity_category,
-            }
-        ),
-        cv.Optional(FEATURES): text_sensor.text_sensor_schema().extend(
-            {
-                cv.Optional(CONF_ICON, default="mdi:cog"): cv.icon,
-                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
-                cv.Optional(
-                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
-                ): cv.entity_category,
-            }
-        ),
-    }
+
+_defined_roode_ids = set()
+# Track which text sensors were explicitly defined for each Roode id so the
+# component can auto-create missing ones with sane defaults.
+configured_sensors = {}
+
+
+def _validate_single_block(config):
+    rid = str(config[CONF_ROODE_ID].id)
+    if rid in _defined_roode_ids:
+        raise cv.Invalid(
+            "Only one 'platform: roode' text_sensor block is allowed per Roode id"
+        )
+    _defined_roode_ids.add(rid)
+    return config
+
+
+def _set_default_names(config):
+    rid = config.get(CONF_ROODE_ID)
+    if hasattr(rid, "id"):
+        rid = rid.id
+    rid = str(rid or "")
+    suffix = f" {rid}" if rid else ""
+    config.setdefault(FEATURES, {"name": f"Roode Enabled Features{suffix}"})
+    config.setdefault(SENSOR_NAME, {"name": f"Roode Sensor Name{suffix}"})
+    config.setdefault(OPTIONAL_SENSORS, {"name": f"Roode Optional Sensors{suffix}"})
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
+            cv.Optional(VERSION): text_sensor.text_sensor_schema().extend(
+                {
+                    cv.Optional(CONF_ICON, default="mdi:git"): cv.icon,
+                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+                    ): cv.entity_category,
+                }
+            ),
+            cv.Optional(ENTRY_EXIT_EVENT): text_sensor.text_sensor_schema().extend(
+                {
+                    cv.Optional(CONF_ICON, default="mdi:sign-direction"): cv.icon,
+                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+                    ): cv.entity_category,
+                }
+            ),
+            cv.Optional(STATUS): text_sensor.text_sensor_schema().extend(
+                {
+                    cv.Optional(CONF_ICON, default="mdi:check-circle"): cv.icon,
+                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+                    ): cv.entity_category,
+                }
+            ),
+            cv.Optional(FEATURES): text_sensor.text_sensor_schema().extend(
+                {
+                    cv.Optional(CONF_ICON, default="mdi:cog"): cv.icon,
+                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+                    ): cv.entity_category,
+                }
+            ),
+            cv.Optional(SENSOR_NAME): text_sensor.text_sensor_schema().extend(
+                {
+                    cv.Optional(CONF_ICON, default="mdi:identifier"): cv.icon,
+                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+                    ): cv.entity_category,
+                }
+            ),
+            cv.Optional(OPTIONAL_SENSORS): text_sensor.text_sensor_schema().extend(
+                {
+                    cv.Optional(CONF_ICON, default="mdi:format-list-checks"): cv.icon,
+                    cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                    cv.Optional(
+                        CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_CONFIG
+                    ): cv.entity_category,
+                }
+            ),
+        }
+    ),
+    _set_default_names,
+    _validate_single_block,
 )
 
 
@@ -67,6 +121,8 @@ async def setup_conf(config, key, hub):
         sens = cg.new_Pvariable(conf[CONF_ID])
         await text_sensor.register_text_sensor(sens, conf)
         cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))
+        rid = str(config[CONF_ROODE_ID].id)
+        configured_sensors.setdefault(rid, set()).add(key)
 
 
 async def to_code(config):

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -177,12 +177,8 @@ text_sensor:
   - platform: roode
     version:
       name: $friendly_name version
-  - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
-  - platform: roode
-    enabled_features:
-      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -183,12 +183,8 @@ text_sensor:
   - platform: roode
     version:
       name: $friendly_name version
-  - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
-  - platform: roode
-    enabled_features:
-      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -176,12 +176,8 @@ text_sensor:
   - platform: roode
     version:
       name: $friendly_name version
-  - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
-  - platform: roode
-    enabled_features:
-      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -179,12 +179,8 @@ text_sensor:
   - platform: roode
     version:
       name: $friendly_name version
-  - platform: roode
     entry_exit_event:
       name: $friendly_name last direction
-  - platform: roode
-    enabled_features:
-      name: $friendly_name enabled features
   - platform: template
     name: $friendly_name Uptime Human Readable
     id: uptime_human


### PR DESCRIPTION
## Summary
- track configured Roode text sensors
- automatically create Sensor Name, Enabled Features and Optional Sensors text sensors when missing
- document that these sensors exist even without a `text_sensor` block
- fix import so auto-created sensors work

## Testing
- `pip install esphome --quiet`
- `python -m py_compile components/roode/text_sensor.py components/roode/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_687eb0ce60088330beac8fdf88423cfe