### PR TITLE
Add exposed sensors service

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,10 +658,11 @@ Use the `exposed_sensors` service to control which sensors Roode exposes to Home
 This service is only available when API services are enabled.
 The setting is saved in flash and restored on boot. Pass `ALL`, `NONE` or a comma
 separated list of sensor names. Omitting the argument only reports the current
-list without making changes. The `exposed_sensors` text sensor publishes the
-resulting list after each call. Because ESPHome does not create new entities at
-runtime, the device restarts after changes so Home Assistant can discover the
-updated sensor list.
+list without making changes. When `NONE` is used the core sensors – Occupancy,
+Presence and Uptime (Human) – remain visible. The `exposed_sensors` text sensor
+publishes the resulting list after each call. Because ESPHome does not create
+new entities at runtime, the device restarts after changes so Home Assistant can
+discover the updated sensor list.
 
 Example calls:
 

--- a/README.md
+++ b/README.md
@@ -660,9 +660,20 @@ separated list of sensor names. Omitting the argument only reports the current
 list without making changes. The `exposed_sensors` text sensor publishes the
 resulting list after each call.
 
-Example automation:
+Example calls:
 
 ```yaml
+# Expose every available sensor
+- service: esphome.roode32_exposed_sensors
+  data:
+    sensors: ALL
+
+# Hide all sensors
+- service: esphome.roode32_exposed_sensors
+  data:
+    sensors: NONE
+
+# Expose only selected sensors
 - service: esphome.roode32_exposed_sensors
   data:
     sensors: "distance_entry, distance_exit"

--- a/README.md
+++ b/README.md
@@ -655,6 +655,7 @@ these sensors.
 ### Exposed sensors service
 
 Use the `exposed_sensors` service to control which sensors Roode exposes to Home Assistant.
+This service is only available when API services are enabled.
 The setting is saved in flash and restored on boot. Pass `ALL`, `NONE` or a comma
 separated list of sensor names. Omitting the argument only reports the current
 list without making changes. The `exposed_sensors` text sensor publishes the

--- a/README.md
+++ b/README.md
@@ -660,7 +660,9 @@ The setting is saved in flash and restored on boot. Pass `ALL`, `NONE` or a comm
 separated list of sensor names. Omitting the argument only reports the current
 list without making changes. When `NONE` is used the core sensors – Occupancy,
 Presence and Uptime (Human) – remain visible while the `enabled_features` text
-sensor is hidden. The `exposed_sensors` text sensor publishes the resulting list
+sensor is hidden. Names in a list are compared case-insensitively and may omit
+the friendly name prefix, so `cpu_usage` matches a sensor named
+"My Counter cpu usage". The `exposed_sensors` text sensor publishes the resulting list
 after each call. Because ESPHome does not create
 new entities at runtime, the device restarts after changes so Home Assistant can
 discover the updated sensor list.
@@ -681,7 +683,7 @@ Example calls:
 # Expose only selected sensors
 - service: esphome.roode32_exposed_sensors
   data:
-    sensors: "distance_entry, distance_exit"
+    sensors: "cpu_usage, interrupt_status"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -661,13 +661,14 @@ separated list of sensor names. Omitting the argument only reports the current
 list without making changes. When `NONE` is used the core sensors – Occupancy,
 Presence and Uptime (Human) – remain visible while the `enabled_features` text
 sensor is hidden. Names in a list are compared case-insensitively and may omit
-the friendly name prefix, so `cpu_usage` matches a sensor named
-"My Counter cpu usage". The `exposed_sensors` text sensor publishes the resulting list
-after each call. Because ESPHome does not create
+the friendly name prefix; include `enabled_features` if you want that text sensor
+visible. The `exposed_sensors` text sensor publishes the resulting list after
+each call. Because ESPHome does not create
 new entities at runtime, the device restarts after changes so Home Assistant can
 discover the updated sensor list. The file `custom_components/roode/services.yaml`
-defines the service so the Home Assistant UI lists `ALL` and `NONE` as options
-while still allowing free text for a list of sensor names.
+defines a service labeled `_ Exposed Sensors` so the Home Assistant UI lists
+`ALL` and `NONE` as options while still allowing free text for a list of sensor
+names.
 
 Only actual sensors can be managed this way; configuration settings such as
 `sampling` or `force_single_core` are not sensor names. Check the entity names in
@@ -690,6 +691,10 @@ Example calls:
 - service: esphome.roode32_exposed_sensors
   data:
     sensors: "cpu_usage, interrupt_status"
+
+# Query current list without changing anything
+- service: esphome.roode32_exposed_sensors
+  data: {}
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -659,8 +659,9 @@ This service is only available when API services are enabled.
 The setting is saved in flash and restored on boot. Pass `ALL`, `NONE` or a comma
 separated list of sensor names. Omitting the argument only reports the current
 list without making changes. When `NONE` is used the core sensors – Occupancy,
-Presence and Uptime (Human) – remain visible. The `exposed_sensors` text sensor
-publishes the resulting list after each call. Because ESPHome does not create
+Presence and Uptime (Human) – remain visible while the `enabled_features` text
+sensor is hidden. The `exposed_sensors` text sensor publishes the resulting list
+after each call. Because ESPHome does not create
 new entities at runtime, the device restarts after changes so Home Assistant can
 discover the updated sensor list.
 

--- a/README.md
+++ b/README.md
@@ -659,7 +659,9 @@ This service is only available when API services are enabled.
 The setting is saved in flash and restored on boot. Pass `ALL`, `NONE` or a comma
 separated list of sensor names. Omitting the argument only reports the current
 list without making changes. The `exposed_sensors` text sensor publishes the
-resulting list after each call.
+resulting list after each call. Because ESPHome does not create new entities at
+runtime, the device restarts after changes so Home Assistant can discover the
+updated sensor list.
 
 Example calls:
 

--- a/README.md
+++ b/README.md
@@ -669,6 +669,10 @@ discover the updated sensor list. The file `custom_components/roode/services.yam
 defines the service so the Home Assistant UI lists `ALL` and `NONE` as options
 while still allowing free text for a list of sensor names.
 
+Only actual sensors can be managed this way; configuration settings such as
+`sampling` or `force_single_core` are not sensor names. Check the entity names in
+Home Assistant or the `exposed_sensors` text sensor before calling the service.
+
 Example calls:
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -665,7 +665,9 @@ the friendly name prefix, so `cpu_usage` matches a sensor named
 "My Counter cpu usage". The `exposed_sensors` text sensor publishes the resulting list
 after each call. Because ESPHome does not create
 new entities at runtime, the device restarts after changes so Home Assistant can
-discover the updated sensor list.
+discover the updated sensor list. The file `custom_components/roode/services.yaml`
+defines the service so the Home Assistant UI lists `ALL` and `NONE` as options
+while still allowing free text for a list of sensor names.
 
 Example calls:
 

--- a/README.md
+++ b/README.md
@@ -425,6 +425,9 @@ text_sensor:
     enabled_features:
       name: $friendly_name enabled features
       ## This sensor is a text_sensor that lists all enabled features
+  - platform: roode
+    exposed_sensors:
+      name: $friendly_name exposed sensors
 ```
 The features string lists items as `name:value` pairs separated by new lines.
 The current output includes: `xshut`, `refresh`, `cpu_mode`, `cpu`,
@@ -475,6 +478,7 @@ calibration:6:01PM
 | `entry_exit_event` | text_sensor | Last entry or exit direction |
 | `sensor_status` (text) | text_sensor | "ok", "timeout", "reinitializing", "error" or "offline" |
 | `enabled_features` | text_sensor | List of active runtime features |
+| `exposed_sensors` | text_sensor | Names of sensors currently exposed to HA |
 
 
 ### Threshold distance
@@ -641,11 +645,28 @@ Optional sensors provide insight into Roode's operation:
   and a text-sensor `sensor_status` exposes the same status string.
 - ROI size and threshold sensors allow live tuning of each zone.
 - `manual_adjustment_count` records people-count corrections.
+- The `exposed_sensors` text sensor lists which sensors are visible to Home Assistant.
 - The sensor automatically restarts if polling stops for the configured `restart_timeout`
   or after 10 consecutive read errors. All restart triggers share this cooldown.
 
 See [extra_sensors_example.yaml](extra_sensors_example.yaml) for how to enable
 these sensors.
+
+### Exposed sensors service
+
+Use the `exposed_sensors` service to control which sensors Roode exposes to Home Assistant.
+The setting is saved in flash and restored on boot. Pass `ALL`, `NONE` or a comma
+separated list of sensor names. Omitting the argument only reports the current
+list without making changes. The `exposed_sensors` text sensor publishes the
+resulting list after each call.
+
+Example automation:
+
+```yaml
+- service: esphome.roode32_exposed_sensors
+  data:
+    sensors: "distance_entry, distance_exit"
+```
 
 
 ## FAQ/Troubleshoot

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -17,7 +17,9 @@ MULTI_CONF = True
 CONF_ROODE_ID = "roode_id"
 
 roode_ns = cg.esphome_ns.namespace("roode")
-Roode = roode_ns.class_("Roode", cg.PollingComponent)
+api_ns = cg.esphome_ns.namespace("api")
+CustomAPIDevice = api_ns.class_("CustomAPIDevice")
+Roode = roode_ns.class_("Roode", cg.PollingComponent, CustomAPIDevice)
 
 CONF_AUTO = "auto"
 CONF_ORIENTATION = "orientation"

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -877,6 +877,9 @@ void Roode::exposed_sensors(std::string sensors) {
   if (exposed_sensors_sensor != nullptr) {
     exposed_sensors_sensor->publish_state(get_exposed_sensors_list());
   }
+  if (!sensors.empty()) {
+    App.safe_reboot();
+  }
 }
 }  // namespace roode
 }  // namespace esphome

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <algorithm>
 #include <ctime>
+#include <sstream>
 
 namespace esphome {
 namespace roode {
@@ -138,6 +139,12 @@ void Roode::setup() {
     return;
   }
 
+  exposed_sensors_pref_ = global_preferences->make_preference<uint32_t>(0xA2);
+  if (!exposed_sensors_pref_.load(&sensor_mask_)) {
+    sensor_mask_ = 0xFFFFFFFF;
+  }
+  register_service(&Roode::exposed_sensors, "exposed_sensors", {"sensors"});
+
   // Initialize filtering options before calibrating so threshold sampling uses
   // the configured window and mode
   entry->set_filter_window(filter_window_);
@@ -244,6 +251,9 @@ void Roode::setup() {
 
   publish_feature_list();
   update_status_text("ok");
+  update_sensor_visibility();
+  if (exposed_sensors_sensor != nullptr)
+    exposed_sensors_sensor->publish_state(get_exposed_sensors_list());
 }
 
 void Roode::update() {
@@ -802,6 +812,64 @@ void Roode::sensor_task(void *param) {
     self->loop_count_++;
     self->update_metrics();
     vTaskDelay(pdMS_TO_TICKS(self->polling_interval_ms_));
+  }
+}
+
+void Roode::register_roode_sensor(sensor::Sensor *sensor) {
+  roode_sensors_.push_back(sensor);
+}
+
+void Roode::update_sensor_visibility() {
+  for (size_t i = 0; i < roode_sensors_.size(); i++) {
+    bool expose = (sensor_mask_ >> i) & 1u;
+    roode_sensors_[i]->set_internal(!expose);
+  }
+}
+
+std::string Roode::get_exposed_sensors_list() const {
+  std::string out;
+  for (size_t i = 0; i < roode_sensors_.size(); i++) {
+    if ((sensor_mask_ >> i) & 1u) {
+      if (!out.empty()) out += ", ";
+      out += roode_sensors_[i]->get_name();
+    }
+  }
+  return out;
+}
+
+static std::string trim(const std::string &s) {
+  size_t start = s.find_first_not_of(" \t");
+  size_t end = s.find_last_not_of(" \t");
+  if (start == std::string::npos) return "";
+  return s.substr(start, end - start + 1);
+}
+
+void Roode::exposed_sensors(std::string sensors) {
+  if (!sensors.empty()) {
+    std::string up = sensors;
+    std::transform(up.begin(), up.end(), up.begin(), ::toupper);
+    if (up == "ALL") {
+      sensor_mask_ = (roode_sensors_.size() >= 32) ? 0xFFFFFFFF : ((1u << roode_sensors_.size()) - 1u);
+    } else if (up == "NONE") {
+      sensor_mask_ = 0;
+    } else {
+      sensor_mask_ = 0;
+      std::stringstream ss(sensors);
+      std::string item;
+      while (std::getline(ss, item, ',')) {
+        std::string name = trim(item);
+        for (size_t i = 0; i < roode_sensors_.size(); i++) {
+          if (roode_sensors_[i]->get_name() == name) {
+            sensor_mask_ |= (1u << i);
+          }
+        }
+      }
+    }
+    exposed_sensors_pref_.save(&sensor_mask_);
+    update_sensor_visibility();
+  }
+  if (exposed_sensors_sensor != nullptr) {
+    exposed_sensors_sensor->publish_state(get_exposed_sensors_list());
   }
 }
 }  // namespace roode

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -143,7 +143,9 @@ void Roode::setup() {
   if (!exposed_sensors_pref_.load(&sensor_mask_)) {
     sensor_mask_ = 0xFFFFFFFF;
   }
+#ifdef USE_API_SERVICES
   register_service(&Roode::exposed_sensors, "exposed_sensors", {"sensors"});
+#endif
 
   // Initialize filtering options before calibrating so threshold sampling uses
   // the configured window and mode

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -310,8 +310,7 @@ void Roode::loop() {
   } else {
     invalid_read_count_ = 0;
   }
-  if (invalid_read_count_ > invalid_distance_limit_ &&
-      (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
+  if (invalid_read_count_ > invalid_distance_limit_ && (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
     ESP_LOGW(TAG, "Consecutive invalid distances, restarting...");
     restart_sensor();
   }
@@ -762,7 +761,6 @@ void Roode::publish_feature_list() {
   log_event(std::string("features_enabled: ") + feature_list);
 }
 
-
 void Roode::update_status_text(const std::string &status) {
   if (status_text_sensor != nullptr && status != last_status_text_) {
     status_text_sensor->publish_state(status);
@@ -781,8 +779,7 @@ void Roode::sensor_task(void *param) {
   for (;;) {
     self->use_sensor_task_ = true;
     uint32_t now = millis();
-    if (self->last_loop_update_ts_ != 0 &&
-        (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
+    if (self->last_loop_update_ts_ != 0 && (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
         (now - self->last_sensor_restart_ts_ > self->restart_timeout_ms_)) {
       ESP_LOGW(TAG, "Sensor unresponsive >%ds, restarting...", self->restart_timeout_ms_ / 1000);
       self->restart_sensor();
@@ -848,7 +845,8 @@ std::string Roode::get_exposed_sensors_list() const {
   std::string out;
   for (size_t i = 0; i < roode_sensors_.size(); i++) {
     if ((sensor_mask_ >> i) & 1u) {
-      if (!out.empty()) out += ", ";
+      if (!out.empty())
+        out += ", ";
       out += roode_sensors_[i]->get_name();
     }
   }
@@ -858,7 +856,8 @@ std::string Roode::get_exposed_sensors_list() const {
 static std::string trim(const std::string &s) {
   size_t start = s.find_first_not_of(" \t");
   size_t end = s.find_last_not_of(" \t");
-  if (start == std::string::npos) return "";
+  if (start == std::string::npos)
+    return "";
   return s.substr(start, end - start + 1);
 }
 
@@ -874,38 +873,49 @@ static std::string canon(const std::string &s) {
 
 void Roode::exposed_sensors(std::string sensors) {
   if (!sensors.empty()) {
+    uint32_t original = sensor_mask_;
+    uint32_t new_mask = sensor_mask_;
+    bool matched = false;
     std::string up = sensors;
     std::transform(up.begin(), up.end(), up.begin(), ::toupper);
     if (up == "ALL") {
-      sensor_mask_ = (roode_sensors_.size() >= 32) ? 0xFFFFFFFF : ((1u << roode_sensors_.size()) - 1u);
+      new_mask = (roode_sensors_.size() >= 32) ? 0xFFFFFFFF : ((1u << roode_sensors_.size()) - 1u);
+      matched = true;
     } else if (up == "NONE") {
-      sensor_mask_ = 0;
+      new_mask = 0;
+      matched = true;
     } else {
-      sensor_mask_ = 0;
+      new_mask = 0;
       std::stringstream ss(sensors);
       std::string item;
       while (std::getline(ss, item, ',')) {
         std::string name = trim(item);
+        if (name.empty())
+          continue;
         std::string needle = canon(name);
         for (size_t i = 0; i < roode_sensors_.size(); i++) {
           std::string hay = canon(roode_sensors_[i]->get_name());
-          if (hay == needle ||
-              (hay.size() > needle.size() &&
-               hay.rfind(needle) == hay.size() - needle.size())) {
-            sensor_mask_ |= (1u << i);
+          if (hay == needle || (hay.size() > needle.size() && hay.rfind(needle) == hay.size() - needle.size())) {
+            new_mask |= (1u << i);
+            matched = true;
           }
         }
       }
     }
-    exposed_sensors_pref_.save(&sensor_mask_);
-    update_sensor_visibility();
+    if (!matched) {
+      ESP_LOGW(TAG, "exposed_sensors: no matching sensors for '%s'", sensors.c_str());
+    } else if (new_mask != original) {
+      sensor_mask_ = new_mask;
+      exposed_sensors_pref_.save(&sensor_mask_);
+      update_sensor_visibility();
+      if (exposed_sensors_sensor != nullptr)
+        exposed_sensors_sensor->publish_state(get_exposed_sensors_list());
+      App.safe_reboot();
+      return;
+    }
   }
-  if (exposed_sensors_sensor != nullptr) {
+  if (exposed_sensors_sensor != nullptr)
     exposed_sensors_sensor->publish_state(get_exposed_sensors_list());
-  }
-  if (!sensors.empty()) {
-    App.safe_reboot();
-  }
 }
 }  // namespace roode
 }  // namespace esphome

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -825,7 +825,7 @@ void Roode::update_sensor_visibility() {
   for (size_t i = 0; i < roode_sensors_.size(); i++) {
     bool expose = (sensor_mask_ >> i) & 1u;
     auto *sens = roode_sensors_[i];
-    bool changed = sens->is_internal() == !expose;
+    bool changed = sens->is_internal() != !expose;
     sens->set_internal(!expose);
     if (changed && expose)
       sens->publish_state(sens->state);

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -857,6 +857,16 @@ static std::string trim(const std::string &s) {
   return s.substr(start, end - start + 1);
 }
 
+static std::string canon(const std::string &s) {
+  std::string out;
+  for (char c : s) {
+    if (c == ' ' || c == '_' || c == '-')
+      continue;
+    out += static_cast<char>(tolower(static_cast<unsigned char>(c)));
+  }
+  return out;
+}
+
 void Roode::exposed_sensors(std::string sensors) {
   if (!sensors.empty()) {
     std::string up = sensors;
@@ -871,8 +881,12 @@ void Roode::exposed_sensors(std::string sensors) {
       std::string item;
       while (std::getline(ss, item, ',')) {
         std::string name = trim(item);
+        std::string needle = canon(name);
         for (size_t i = 0; i < roode_sensors_.size(); i++) {
-          if (roode_sensors_[i]->get_name() == name) {
+          std::string hay = canon(roode_sensors_[i]->get_name());
+          if (hay == needle ||
+              (hay.size() > needle.size() &&
+               hay.rfind(needle) == hay.size() - needle.size())) {
             sensor_mask_ |= (1u << i);
           }
         }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -824,7 +824,11 @@ void Roode::register_roode_sensor(sensor::Sensor *sensor) {
 void Roode::update_sensor_visibility() {
   for (size_t i = 0; i < roode_sensors_.size(); i++) {
     bool expose = (sensor_mask_ >> i) & 1u;
-    roode_sensors_[i]->set_internal(!expose);
+    auto *sens = roode_sensors_[i];
+    bool changed = sens->is_internal() == !expose;
+    sens->set_internal(!expose);
+    if (changed && expose)
+      sens->publish_state(sens->state);
   }
 }
 

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -830,6 +830,13 @@ void Roode::update_sensor_visibility() {
     if (changed && expose)
       sens->publish_state(sens->state);
   }
+  if (enabled_features_sensor != nullptr) {
+    bool expose = sensor_mask_ != 0;
+    bool changed = enabled_features_sensor->is_internal() != !expose;
+    enabled_features_sensor->set_internal(!expose);
+    if (changed && expose)
+      enabled_features_sensor->publish_state(enabled_features_sensor->state);
+  }
 }
 
 std::string Roode::get_exposed_sensors_list() const {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -833,7 +833,7 @@ void Roode::update_sensor_visibility() {
       sens->publish_state(sens->state);
   }
   if (enabled_features_sensor != nullptr) {
-    bool expose = sensor_mask_ != 0;
+    bool expose = (sensor_mask_ >> FEATURES_BIT) & 1u;
     bool changed = enabled_features_sensor->is_internal() != !expose;
     enabled_features_sensor->set_internal(!expose);
     if (changed && expose)
@@ -849,6 +849,11 @@ std::string Roode::get_exposed_sensors_list() const {
         out += ", ";
       out += roode_sensors_[i]->get_name();
     }
+  }
+  if (enabled_features_sensor != nullptr && ((sensor_mask_ >> FEATURES_BIT) & 1u)) {
+    if (!out.empty())
+      out += ", ";
+    out += enabled_features_sensor->get_name();
   }
   return out;
 }
@@ -880,6 +885,8 @@ void Roode::exposed_sensors(std::string sensors) {
     std::transform(up.begin(), up.end(), up.begin(), ::toupper);
     if (up == "ALL") {
       new_mask = (roode_sensors_.size() >= 32) ? 0xFFFFFFFF : ((1u << roode_sensors_.size()) - 1u);
+      if (enabled_features_sensor != nullptr)
+        new_mask |= FEATURES_MASK;
       matched = true;
     } else if (up == "NONE") {
       new_mask = 0;
@@ -897,6 +904,13 @@ void Roode::exposed_sensors(std::string sensors) {
           std::string hay = canon(roode_sensors_[i]->get_name());
           if (hay == needle || (hay.size() > needle.size() && hay.rfind(needle) == hay.size() - needle.size())) {
             new_mask |= (1u << i);
+            matched = true;
+          }
+        }
+        if (enabled_features_sensor != nullptr) {
+          std::string hay = canon(enabled_features_sensor->get_name());
+          if (hay == needle || (hay.size() > needle.size() && hay.rfind(needle) == hay.size() - needle.size())) {
+            new_mask |= FEATURES_MASK;
             matched = true;
           }
         }

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -819,6 +819,11 @@ void Roode::sensor_task(void *param) {
 
 void Roode::register_roode_sensor(sensor::Sensor *sensor) {
   roode_sensors_.push_back(sensor);
+  size_t idx = roode_sensors_.size() - 1;
+  bool expose = (sensor_mask_ >> idx) & 1u;
+  sensor->set_internal(!expose);
+  if (expose)
+    sensor->publish_state(sensor->state);
 }
 
 void Roode::update_sensor_visibility() {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -26,6 +26,9 @@ namespace roode {
 static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
 static const char *const CALIBRATION = "Sensor Calibration";
+// Bit index used to store the visibility state of the enabled_features text sensor
+static const uint8_t FEATURES_BIT = 31;
+static const uint32_t FEATURES_MASK = 1u << FEATURES_BIT;
 
 /*
 Use the VL53L1X_SetTimingBudget function to set the TB in milliseconds. The TB
@@ -110,7 +113,13 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void set_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
   void set_sensor_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
   void set_interrupt_status_sensor(sensor::Sensor *sens) { interrupt_status_sensor = sens; }
-  void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }
+  void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) {
+    enabled_features_sensor = sensor_;
+    if (sensor_ != nullptr) {
+      bool expose = (sensor_mask_ >> FEATURES_BIT) & 1u;
+      sensor_->set_internal(!expose);
+    }
+  }
   void set_sensor_status_text_sensor(text_sensor::TextSensor *sensor_) { status_text_sensor = sensor_; }
   void set_manual_adjustment_sensor(sensor::Sensor *sens) { manual_adjustment_sensor = sens; }
   void set_exposed_sensors_text_sensor(text_sensor::TextSensor *sensor_) { exposed_sensors_sensor = sensor_; }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -8,6 +8,7 @@
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
+#include "esphome/components/api/custom_api_device.h"
 #include "esphome/core/log.h"
 #include "../vl53l1x/vl53l1x.h"
 #include "esphome/core/preferences.h"
@@ -55,7 +56,7 @@ static int time_budget_in_ms_medium_long = 50;
 static int time_budget_in_ms_long = 100;
 static int time_budget_in_ms_max = 200;  // max range: 4m
 
-class Roode : public PollingComponent {
+class Roode : public PollingComponent, public api::CustomAPIDevice {
  public:
   Roode() { instance_ = this; }
   void setup() override;
@@ -112,6 +113,7 @@ class Roode : public PollingComponent {
   void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }
   void set_sensor_status_text_sensor(text_sensor::TextSensor *sensor_) { status_text_sensor = sensor_; }
   void set_manual_adjustment_sensor(sensor::Sensor *sens) { manual_adjustment_sensor = sens; }
+  void set_exposed_sensors_text_sensor(text_sensor::TextSensor *sensor_) { exposed_sensors_sensor = sensor_; }
   void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
   void set_force_single_core(bool val) { force_single_core_ = val; }
   void set_calibration_persistence(bool val) { calibration_persistence_ = val; }
@@ -136,6 +138,10 @@ class Roode : public PollingComponent {
   void apply_cpu_optimizations(float cpu);
   void reset_cpu_optimizations(float cpu);
   void update_metrics();
+  void register_roode_sensor(sensor::Sensor *sensor);
+  void exposed_sensors(std::string sensors);
+  std::string get_exposed_sensors_list() const;
+  void update_sensor_visibility();
   Zone *entry = new Zone(0);
   Zone *exit = new Zone(1);
   static void log_event(const std::string &msg);
@@ -167,6 +173,11 @@ class Roode : public PollingComponent {
   text_sensor::TextSensor *status_text_sensor{nullptr};
   sensor::Sensor *manual_adjustment_sensor{nullptr};
   sensor::Sensor *interrupt_status_sensor{nullptr};
+  text_sensor::TextSensor *exposed_sensors_sensor{nullptr};
+
+  std::vector<sensor::Sensor *> roode_sensors_{};
+  ESPPreferenceObject exposed_sensors_pref_;
+  uint32_t sensor_mask_{0xFFFFFFFF};
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -156,51 +156,68 @@ async def to_code(config):
     if CONF_DISTANCE_ENTRY in config:
         distance = await sensor.new_sensor(config[CONF_DISTANCE_ENTRY])
         cg.add(var.set_distance_entry(distance))
+        cg.add(var.register_roode_sensor(distance))
     if CONF_DISTANCE_EXIT in config:
         distance = await sensor.new_sensor(config[CONF_DISTANCE_EXIT])
         cg.add(var.set_distance_exit(distance))
+        cg.add(var.register_roode_sensor(distance))
     if CONF_MAX_THRESHOLD_ENTRY in config:
         count = await sensor.new_sensor(config[CONF_MAX_THRESHOLD_ENTRY])
         cg.add(var.set_max_threshold_entry_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_MAX_THRESHOLD_EXIT in config:
         count = await sensor.new_sensor(config[CONF_MAX_THRESHOLD_EXIT])
         cg.add(var.set_max_threshold_exit_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_MIN_THRESHOLD_ENTRY in config:
         count = await sensor.new_sensor(config[CONF_MIN_THRESHOLD_ENTRY])
         cg.add(var.set_min_threshold_entry_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_MIN_THRESHOLD_EXIT in config:
         count = await sensor.new_sensor(config[CONF_MIN_THRESHOLD_EXIT])
         cg.add(var.set_min_threshold_exit_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_ROI_HEIGHT_ENTRY in config:
         count = await sensor.new_sensor(config[CONF_ROI_HEIGHT_ENTRY])
         cg.add(var.set_entry_roi_height_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_ROI_WIDTH_ENTRY in config:
         count = await sensor.new_sensor(config[CONF_ROI_WIDTH_ENTRY])
         cg.add(var.set_entry_roi_width_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_ROI_HEIGHT_EXIT in config:
         count = await sensor.new_sensor(config[CONF_ROI_HEIGHT_EXIT])
         cg.add(var.set_exit_roi_height_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_ROI_WIDTH_EXIT in config:
         count = await sensor.new_sensor(config[CONF_ROI_WIDTH_EXIT])
         cg.add(var.set_exit_roi_width_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if SENSOR_STATUS in config:
         count = await sensor.new_sensor(config[SENSOR_STATUS])
         cg.add(var.set_sensor_status_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_LOOP_TIME in config:
         count = await sensor.new_sensor(config[CONF_LOOP_TIME])
         cg.add(var.set_loop_time_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_CPU_USAGE in config:
         count = await sensor.new_sensor(config[CONF_CPU_USAGE])
         cg.add(var.set_cpu_usage_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_RAM_FREE in config:
         count = await sensor.new_sensor(config[CONF_RAM_FREE])
         cg.add(var.set_ram_free_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_FLASH_FREE in config:
         count = await sensor.new_sensor(config[CONF_FLASH_FREE])
         cg.add(var.set_flash_free_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_INTERRUPT_STATUS in config:
         count = await sensor.new_sensor(config[CONF_INTERRUPT_STATUS])
         cg.add(var.set_interrupt_status_sensor(count))
+        cg.add(var.register_roode_sensor(count))
     if CONF_MANUAL_ADJUST in config:
         count = await sensor.new_sensor(config[CONF_MANUAL_ADJUST])
         cg.add(var.set_manual_adjustment_sensor(count))
+        cg.add(var.register_roode_sensor(count))

--- a/components/roode/text_sensor.py
+++ b/components/roode/text_sensor.py
@@ -15,8 +15,9 @@ VERSION = "version"
 ENTRY_EXIT_EVENT = "entry_exit_event"
 STATUS = "sensor_status"
 FEATURES = "enabled_features"
+EXPOSED = "exposed_sensors"
 
-TYPES = [VERSION, ENTRY_EXIT_EVENT, STATUS, FEATURES]
+TYPES = [VERSION, ENTRY_EXIT_EVENT, STATUS, FEATURES, EXPOSED]
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -51,6 +52,15 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(FEATURES): text_sensor.text_sensor_schema().extend(
             {
                 cv.Optional(CONF_ICON, default="mdi:cog"): cv.icon,
+                cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
+                cv.Optional(
+                    CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC
+                ): cv.entity_category,
+            }
+        ),
+        cv.Optional(EXPOSED): text_sensor.text_sensor_schema().extend(
+            {
+                cv.Optional(CONF_ICON, default="mdi:eye"): cv.icon,
                 cv.GenerateID(): cv.declare_id(text_sensor.TextSensor),
                 cv.Optional(
                     CONF_ENTITY_CATEGORY, default=ENTITY_CATEGORY_DIAGNOSTIC

--- a/custom_components/roode/services.yaml
+++ b/custom_components/roode/services.yaml
@@ -1,5 +1,5 @@
 exposed_sensors:
-  name: Exposed Sensors
+  name: "_ Exposed Sensors"
   description: Control which sensors the Roode device exposes to Home Assistant.
   fields:
     sensors:

--- a/custom_components/roode/services.yaml
+++ b/custom_components/roode/services.yaml
@@ -1,0 +1,13 @@
+exposed_sensors:
+  name: Exposed Sensors
+  description: Control which sensors the Roode device exposes to Home Assistant.
+  fields:
+    sensors:
+      name: Sensors
+      description: "Which sensors to expose. Use ALL, NONE or provide a comma-separated list of sensor names."
+      selector:
+        select:
+          options:
+            - ALL
+            - NONE
+          custom_value: true

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -48,4 +48,7 @@ Example calls:
 - service: esphome.roode32_exposed_sensors
   data:
     sensors: "distance_entry, distance_exit"
+
+The firmware restarts after changes so newly exposed sensors are discovered by
+Home Assistant.
 ```

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -27,9 +27,11 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
 To control which sensors are visible in Home Assistant, call the `exposed_sensors`
 service (requires API services to be enabled) with one of three options:
 
-* `ALL` – expose every Roode sensor
-* `NONE` – hide all optional sensors (Occupancy, Presence and Uptime remain)
-* A comma-separated list of specific sensor names
+* `ALL` – expose every Roode sensor and the `enabled_features` text sensor
+* `NONE` – hide all optional sensors. Only Occupancy, Presence and Uptime
+  sensors stay visible and the `enabled_features` text sensor is hidden
+* A comma-separated list of specific sensor names. The `enabled_features` text
+  sensor remains visible
 
 Example calls:
 

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -34,9 +34,15 @@ service (requires API services to be enabled) with one of three options:
   case-insensitively and may omit the friendly name prefix. The `enabled_features`
   text sensor remains visible
 
+The repository includes `custom_components/roode/services.yaml` so the service
+UI in Home Assistant lists `ALL` and `NONE` while allowing custom values.
+
 Example calls:
 
 ```yaml
+# The Home Assistant service UI lists ALL and NONE as options
+# and allows typing a comma-separated list thanks to
+# custom_components/roode/services.yaml
 # Expose all sensors
 - service: esphome.roode32_exposed_sensors
   data:

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -25,9 +25,26 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
 ```
 
 To control which sensors are visible in Home Assistant, call the `exposed_sensors`
-service with a comma-separated list of sensor names, or `ALL`/`NONE`:
+service with one of three options:
+
+* `ALL` – expose every Roode sensor
+* `NONE` – hide all sensors
+* A comma-separated list of specific sensor names
+
+Example calls:
 
 ```yaml
+# Expose all sensors
+- service: esphome.roode32_exposed_sensors
+  data:
+    sensors: ALL
+
+# Hide all sensors
+- service: esphome.roode32_exposed_sensors
+  data:
+    sensors: NONE
+
+# Expose just the entry and exit distance sensors
 - service: esphome.roode32_exposed_sensors
   data:
     sensors: "distance_entry, distance_exit"

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -30,8 +30,9 @@ service (requires API services to be enabled) with one of three options:
 * `ALL` – expose every Roode sensor and the `enabled_features` text sensor
 * `NONE` – hide all optional sensors. Only Occupancy, Presence and Uptime
   sensors stay visible and the `enabled_features` text sensor is hidden
-* A comma-separated list of specific sensor names. The `enabled_features` text
-  sensor remains visible
+* A comma-separated list of specific sensor names. Names are matched
+  case-insensitively and may omit the friendly name prefix. The `enabled_features`
+  text sensor remains visible
 
 Example calls:
 
@@ -46,10 +47,10 @@ Example calls:
   data:
     sensors: NONE
 
-# Expose just the entry and exit distance sensors
+# Expose only selected sensors
 - service: esphome.roode32_exposed_sensors
   data:
-    sensors: "distance_entry, distance_exit"
+    sensors: "cpu_usage, interrupt_status"
 
 The firmware restarts after changes so newly exposed sensors are discovered by
 Home Assistant.

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -25,7 +25,7 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
 ```
 
 To control which sensors are visible in Home Assistant, call the `exposed_sensors`
-service with one of three options:
+service (requires API services to be enabled) with one of three options:
 
 * `ALL` – expose every Roode sensor
 * `NONE` – hide all sensors

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -37,6 +37,10 @@ service (requires API services to be enabled) with one of three options:
 The repository includes `custom_components/roode/services.yaml` so the service
 UI in Home Assistant lists `ALL` and `NONE` while allowing custom values.
 
+Only real sensors can be selected. Configuration parameters like `sampling` or
+`force_single_core` are not sensors and will be ignored. Check the names shown
+by the `exposed_sensors` text sensor before calling the service.
+
 Example calls:
 
 ```yaml

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -20,6 +20,15 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
     entity_id: input_number.set_people32
   action:
     service: esphome.roode32_set_counter
-    data:
-      newCount: "{{ states('input_number.set_people32') | int }}"
+  data:
+    newCount: "{{ states('input_number.set_people32') | int }}"
+```
+
+To control which sensors are visible in Home Assistant, call the `exposed_sensors`
+service with a comma-separated list of sensor names, or `ALL`/`NONE`:
+
+```yaml
+- service: esphome.roode32_exposed_sensors
+  data:
+    sensors: "distance_entry, distance_exit"
 ```

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -28,7 +28,7 @@ To control which sensors are visible in Home Assistant, call the `exposed_sensor
 service (requires API services to be enabled) with one of three options:
 
 * `ALL` – expose every Roode sensor
-* `NONE` – hide all sensors
+* `NONE` – hide all optional sensors (Occupancy, Presence and Uptime remain)
 * A comma-separated list of specific sensor names
 
 Example calls:

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -31,11 +31,12 @@ service (requires API services to be enabled) with one of three options:
 * `NONE` – hide all optional sensors. Only Occupancy, Presence and Uptime
   sensors stay visible and the `enabled_features` text sensor is hidden
 * A comma-separated list of specific sensor names. Names are matched
-  case-insensitively and may omit the friendly name prefix. The `enabled_features`
-  text sensor remains visible
+  case-insensitively and may omit the friendly name prefix. Include
+  `enabled_features` in the list if you want that text sensor visible
 
 The repository includes `custom_components/roode/services.yaml` so the service
-UI in Home Assistant lists `ALL` and `NONE` while allowing custom values.
+named `_ Exposed Sensors` appears in the UI, listing `ALL` and `NONE` while
+allowing custom values.
 
 Only real sensors can be selected. Configuration parameters like `sampling` or
 `force_single_core` are not sensors and will be ignored. Check the names shown
@@ -61,6 +62,10 @@ Example calls:
 - service: esphome.roode32_exposed_sensors
   data:
     sensors: "cpu_usage, interrupt_status"
+
+# Query current list without changing anything
+- service: esphome.roode32_exposed_sensors
+  data: {}
 
 The firmware restarts after changes so newly exposed sensors are discovered by
 Home Assistant.


### PR DESCRIPTION
## Summary
- create API service to manage which Roode sensors are exposed
- track sensors and persist exposure settings
- register sensors when created
- add text sensor `exposed_sensors`

## Testing
- `esphome config ci/esp32.yaml`
- `esphome compile ci/esp32.yaml` *(fails: blocked network during toolchain install)*

------
https://chatgpt.com/codex/tasks/task_e_6881a596faf88330b0cba20d9fa5fd49