### PR TITLE
Add persisted configuration entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ common/wifi.yaml
 common/secrets.yaml
 secrets.yaml
 __pycache__
+ci/.esphome/
+ci/.gitignore

--- a/README.md
+++ b/README.md
@@ -182,21 +182,6 @@ roode:
     # min: 50mm
     # max: 234cm
 
-  # Persist calibration data so thresholds survive restarts
-  calibration_persistence: true
-
-  # Jitter reduction options
-  filter_mode: median  # min, median or percentile10
-  # Increase the window to 7 or 9 for heavy noise, drop to 3 for faster response
-  filter_window: 5     # number of samples used by the filter
-  # Log interrupt fallback events and XSHUT recoveries
-  log_fallback_events: true
-  # Disable dual core tasking if needed
-  force_single_core: false
-  # Restart if readings are 0 or >4000mm too many times
-  invalid_distance_limit: 10
-  # Minimum time between automatic sensor restarts
-  restart_timeout: 30s
   # Event logs show xshut power cycles, interrupt fallbacks and manual adjustments
 
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
@@ -249,7 +234,8 @@ Roode prefers the interrupt pin for efficient updates. When `interrupt` is defin
 On ESP32 targets Roode tries to run the sensor loop on the second CPU core so
 Wi‑Fi and other ESPHome tasks stay responsive.  If the task fails to start or
 when running on an ESP8266 the code automatically falls back to a single‑core
-loop.  You can force single‑core mode with `force_single_core: true`.
+loop.  You can force single‑core mode with the
+`input_boolean.roode_force_single_core` entity.
 
 ### Sampling and Filtering
 
@@ -317,19 +303,25 @@ reflections cause false triggers.
 | `vl53l1x.timeout` | Optional | `2s` | How long to wait for a measurement | Long ranges may need more time | Increase in 500&nbsp;ms steps until errors stop | `timeout: 2s` | `timeout: 3s` |
 | `vl53l1x.pins.interrupt` | Optional | none | GPIO for data ready signal | Efficient updates | Use if you can spare a pin | *(not set)* | `interrupt: GPIO32` |
 | `vl53l1x.calibration.ranging` | Optional | `auto` | Measurement range preset | Known distance extremes | Pick the shortest range that works | `ranging: auto` | `ranging: long` |
-| `vl53l1x.calibration.offset` | Optional | none | Distance offset correction | Sensor mounted behind glass | Set the measured mm offset after calibration | *(not set)* | `offset: 20mm` |
-| `vl53l1x.calibration.crosstalk` | Optional | none | Photon count correction | Strong reflections | Only adjust with ST's calibration output | *(not set)* | `crosstalk: 100000cps` |
-| `roode.sampling` | Optional | `2` | Number of readings averaged | Smoother or faster response | Try 3–5 for noisy areas; above 5 adds lag | `sampling: 2` | `sampling: 5` |
+| `input_number.roode_calibration_offset` | Optional | `0` | Distance offset correction | Sensor mounted behind glass | Set the measured mm offset after calibration | – | – |
+| `input_number.roode_calibration_crosstalk` | Optional | `0` | Photon count correction | Strong reflections | Only adjust with ST's calibration output | – | – |
+| `input_number.roode_sampling` | Optional | `2` | Number of readings averaged | Smoother or faster response | Try 3–5 for noisy areas; above 5 adds lag | – | – |
 | `roode.orientation` | Optional | `parallel` | Sensor pad orientation | Sensor rotated 90° | Set to `perpendicular` | `orientation: parallel` | `orientation: perpendicular` |
 | `roode.roi` | Optional | `h16 w6` | Size of measurement window | Narrow doorway or wide hall | Change by 2–4 units or use `auto` to learn | `roi: { height: 16, width: 6 }` | `roi: auto` |
-| `roode.detection_thresholds` | Optional | `min:0% max:85%` | Distance limits for detecting people | Sensor too close or far from traffic | Raise `min` ~5% (or ~50 mm) each time | `detection_thresholds: { min: 5%, max: 85% }` | `detection_thresholds: { min: 50mm, max: 234cm }` |
-| `roode.calibration_persistence` | Optional | `false` | Save thresholds in flash | Sensor reboots often | Enable to keep tuning | `calibration_persistence: false` | `calibration_persistence: true` |
-| `roode.filter_mode` & `roode.filter_window` | Optional | `min` / `5` | How samples are combined and window size | Noisy environment | Use `median`/`percentile10` with larger windows | `filter_mode: min`<br>`filter_window: 5` | `filter_mode: percentile10`<br>`filter_window: 9` |
-| `roode.log_fallback_events` | Optional | `false` | Record INT/XSHUT fallback events | Debugging unexpected counts | Enable while testing | `log_fallback_events: false` | `log_fallback_events: true` |
-| `roode.force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | `force_single_core: false` | `force_single_core: true` |
-| `roode.invalid_distance_limit` | Optional | `10` | Consecutive suspect readings before restart | Sporadic zero/4 m values | Increase if noise triggers resets | `invalid_distance_limit: 10` | `invalid_distance_limit: 20` |
-| `roode.restart_timeout` | Optional | `30s` | Cooldown and timeout before restart | Slow updates or many resets | Shorten for faster recovery | `restart_timeout: 30s` | `restart_timeout: 15s` |
-| `roode.zones.invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | `zones: { invert: false }` | `zones: { invert: true }` |
+| `input_number.roode_detection_min_threshold` & `input_number.roode_detection_max_threshold` | Optional | `0` / `85` | Distance limits for detecting people | Sensor too close or far from traffic | Raise `min` ~5% each time | – | – |
+| `input_boolean.roode_calibration_persistence` | Optional | `false` | Save thresholds in flash | Sensor reboots often | Enable to keep tuning | – | – |
+| `input_select.roode_filter_mode` & `input_number.roode_filter_window` | Optional | `min` / `5` | How samples are combined and window size | Noisy environment | Use `median`/`percentile10` with larger windows | – | – |
+| `input_boolean.roode_log_fallback_events` | Optional | `false` | Record INT/XSHUT fallback events | Debugging unexpected counts | Enable while testing | – | – |
+| `input_boolean.roode_force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | – | – |
+| `input_number.roode_invalid_distance_limit` | Optional | `10` | Consecutive suspect readings before restart | Sporadic zero/4 m values | Increase if noise triggers resets | – | – |
+| `input_number.roode_restart_timeout` | Optional | `30` | Cooldown and timeout before restart | Slow updates or many resets | Shorten for faster recovery | – | – |
+| `input_number.roode_entry_roi_height` & `input_number.roode_exit_roi_height` | Optional | `16` | ROI height for entry and exit zones | Mounting constraints require smaller area | Reduce or enlarge to fit doorway | – | – |
+| `input_number.roode_entry_roi_center` & `input_number.roode_exit_roi_center` | Optional | auto | Override ROI center location | Offset doorway from sensor center | Tune until zones cover the walkway | – | – |
+| `input_number.roode_entry_threshold_min` & `input_number.roode_entry_threshold_max` | Optional | `0` / `85` | Entry zone detection thresholds | Different lighting or reflections | Raise or lower independently | – | – |
+| `input_number.roode_exit_threshold_min` & `input_number.roode_exit_threshold_max` | Optional | `0` / `85` | Exit zone detection thresholds | Different lighting or reflections | Raise or lower independently | – | – |
+| `input_number.roode_roi_height` & `input_number.roode_roi_width` | Optional | `16` / `6` | ROI size when zones not split | Use when not defining entry/exit zones | Adjust to match hallway width | – | – |
+| `input_boolean.roode_zones_invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | – | – |
+| `input_select.roode_refresh_mode` | Optional | `interrupt` | Choose interrupt or polling mode | Debugging | Force polling if interrupts unreliable | – | – |
 | `roode.zones.entry/exit` | Optional | none | Per-zone ROI and thresholds | Uneven hallway or obstacles | Tweak each zone separately as needed | *(not set)* | `zones:`<br>`  exit:`<br>`    roi:`<br>`      height: 8` |
 
 
@@ -445,6 +437,76 @@ ram:309KB
 flash:16MB
 calibration_value:1399
 calibration:6:01PM
+```
+
+#### UI-controlled settings
+
+Add any of the input numbers, selects or switches from the table above under the
+`roode` platform to expose them in Home Assistant. Each entity retains its value
+across reboots and updates Roode immediately when changed. Updated values are pushed back
+to Home Assistant after calibration so both sides stay in sync. The block below lists every
+available option; remove any you do not need. When created for the first time each
+entity will use Roode's built-in default value. These defaults are hardcoded in
+firmware so the device always boots with sensible numbers even before Home Assistant
+has saved a value.
+
+```yaml
+number:
+  - platform: roode
+    invalid_distance_limit:
+      name: Invalid Distance Limit
+    detection_threshold_min:
+      name: Detection Min
+    detection_threshold_max:
+      name: Detection Max
+    restart_timeout:
+      name: Restart Timeout
+    sampling:
+      name: Sampling Size
+    filter_window:
+      name: Filter Window
+    entry_threshold_min:
+      name: Entry Min Threshold
+    entry_threshold_max:
+      name: Entry Max Threshold
+    exit_threshold_min:
+      name: Exit Min Threshold
+    exit_threshold_max:
+      name: Exit Max Threshold
+    entry_roi_height:
+      name: Entry ROI Height
+    entry_roi_center:
+      name: Entry ROI Center
+    exit_roi_height:
+      name: Exit ROI Height
+    exit_roi_center:
+      name: Exit ROI Center
+    roi_height:
+      name: ROI Height
+    roi_width:
+      name: ROI Width
+    calibration_offset:
+      name: Calibration Offset
+    calibration_crosstalk:
+      name: Calibration Crosstalk
+select:
+  - platform: roode
+    calibration_ranging:
+      name: Ranging Mode
+    filter_mode:
+      name: Filter Mode
+    refresh:
+      name: Refresh Mode
+switch:
+  - platform: roode
+    log_fallback_events:
+      name: Log Fallback Events
+    force_single_core:
+      name: Force Single Core
+    calibration_persistence:
+      name: Calibration Persistence
+    zones_invert:
+      name: Invert Zones
 ```
 
 #### Sensor Reference
@@ -607,20 +669,21 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | Feature text sensor | Reports enabled and fallback features for diagnostics |
 | Manual adjustment counter | Tracks user corrections to the people count |
 | Diagnostic sensors | Report INT/XSHUT pin states and other metrics |
-| Polling timeout recovery | Restarts the sensor if no data arrives for `restart_timeout` |
+| Polling timeout recovery | Restarts the sensor if no data arrives for `input_number.roode_restart_timeout` |
 | Consecutive failure counter | Soft-resets the sensor after 10 read errors |
 | Consecutive invalid distance recovery | Restarts the sensor after too many suspect readings |
-| Recovery cooldown | Prevents another restart for `restart_timeout` |
+| Recovery cooldown | Prevents another restart for `input_number.roode_restart_timeout` |
 | Sensor status reporting | Text sensor shows `ok`, `timeout`, `reinitializing`, `error` or `offline` |
 | Event logging | Logs sensor power cycles, fallback reasons, and manual adjustments |
 | Colored logs | Normal info in green, details in yellow, failures in red |
 
 ## Logging and Diagnostics
 
-Roode prints key events to the ESPHome logger. Set `log_fallback_events: true`
-in the `roode:` section to include interrupt fallbacks and XSHUT recovery
-details. Event logs cover power cycles of the sensor, automatic changes between
-interrupt and polling mode, and manual adjustments to the people count.
+Roode prints key events to the ESPHome logger. Enable the
+`input_boolean.roode_log_fallback_events` entity to include interrupt
+fallbacks and XSHUT recovery details. Event logs cover power cycles of the
+sensor, automatic changes between interrupt and polling mode, and manual
+adjustments to the people count.
 
 ### Feature text sensor
 
@@ -641,7 +704,7 @@ Optional sensors provide insight into Roode's operation:
   and a text-sensor `sensor_status` exposes the same status string.
 - ROI size and threshold sensors allow live tuning of each zone.
 - `manual_adjustment_count` records people-count corrections.
-- The sensor automatically restarts if polling stops for the configured `restart_timeout`
+- The sensor automatically restarts if polling stops for the configured `input_number.roode_restart_timeout`
   or after 10 consecutive read errors. All restart triggers share this cooldown.
 
 See [extra_sensors_example.yaml](extra_sensors_example.yaml) for how to enable

--- a/components/persisted_number/__init__.py
+++ b/components/persisted_number/__init__.py
@@ -8,6 +8,8 @@ from esphome.const import (
     CONF_RESTORE_VALUE,
 )
 
+AUTO_LOAD = ["number"]
+
 PersistedNumber = number.number_ns.class_(
     "PersistedNumber", number.Number, cg.Component
 )
@@ -25,6 +27,7 @@ async def new_persisted_number(
     min_value: float,
     max_value: float,
     step: Optional[float] = None,
+    default_value: Optional[float] = None,
 ):
     var = await number.new_number(
         config, min_value=min_value, max_value=max_value, step=step
@@ -32,4 +35,6 @@ async def new_persisted_number(
     await cg.register_component(var, config)
     if CONF_RESTORE_VALUE in config:
         cg.add(var.set_restore_value(config[CONF_RESTORE_VALUE]))
+    if default_value is not None:
+        cg.add(var.set_default_value(default_value))
     return var

--- a/components/persisted_number/persisted_number.cpp
+++ b/components/persisted_number/persisted_number.cpp
@@ -12,17 +12,12 @@ auto PersistedNumber::control(float newValue) -> void {
 }
 
 auto PersistedNumber::setup() -> void {
-  float value;
-  if (!this->restore_value_) {
-    value = this->traits.get_min_value();
+  this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+  float value = this->default_value_;
+  if (this->restore_value_ && this->pref_.load(&value)) {
+    ESP_LOGI("number", "'%s': Restored state %f", this->get_name().c_str(), value);
   } else {
-    this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
-    if (this->pref_.load(&value)) {
-      ESP_LOGI("number", "'%s': Restored state %f", this->get_name().c_str(), value);
-    } else {
-      ESP_LOGI("number", "'%s': No previous state found", this->get_name().c_str());
-      value = this->traits.get_min_value();
-    }
+    ESP_LOGI("number", "'%s': Using default %f", this->get_name().c_str(), value);
   }
   this->publish_state(value);
 }

--- a/components/persisted_number/persisted_number.h
+++ b/components/persisted_number/persisted_number.h
@@ -11,12 +11,14 @@ class PersistedNumber : public number::Number, public Component {
  public:
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
   void set_restore_value(bool restore) { this->restore_value_ = restore; }
+  void set_default_value(float value) { this->default_value_ = value; }
   void setup() override;
 
  protected:
   void control(float value) override;
 
   bool restore_value_{false};
+  float default_value_{0.0f};
   ESPPreferenceObject pref_;
 };
 

--- a/components/persisted_select/__init__.py
+++ b/components/persisted_select/__init__.py
@@ -1,0 +1,23 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import select
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["select"]
+
+PersistedSelect = select.select_ns.class_(
+    "PersistedSelect", select.Select, cg.Component
+)
+
+PERSISTED_SELECT_SCHEMA = select.select_schema(PersistedSelect).extend(
+    {
+        cv.GenerateID(): cv.declare_id(PersistedSelect),
+        cv.Optional("options", default=[]): cv.ensure_list(cv.string),
+    }
+)
+
+
+async def new_persisted_select(config):
+    var = await select.new_select(config, options=config["options"])
+    await cg.register_component(var, config)
+    return var

--- a/components/persisted_select/persisted_select.cpp
+++ b/components/persisted_select/persisted_select.cpp
@@ -1,0 +1,29 @@
+#include "persisted_select.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace select {
+
+void PersistedSelect::control(const std::string &value) {
+  this->publish_state(value);
+  const auto &options = this->traits.get_options();
+  auto it = std::find(options.begin(), options.end(), value);
+  uint8_t idx = it == options.end() ? 0 : static_cast<uint8_t>(it - options.begin());
+  this->pref_.save(&idx);
+}
+
+void PersistedSelect::setup() {
+  const auto &options = this->traits.get_options();
+  this->pref_ = global_preferences->make_preference<uint8_t>(this->get_object_id_hash());
+  uint8_t idx = 0;
+  if (this->pref_.load(&idx) && idx < options.size()) {
+    ESP_LOGI("select", "'%s': Restored option %u", this->get_name().c_str(), idx);
+  } else {
+    idx = 0;
+  }
+  if (!options.empty())
+    this->publish_state(options[idx]);
+}
+
+}  // namespace select
+}  // namespace esphome

--- a/components/persisted_select/persisted_select.h
+++ b/components/persisted_select/persisted_select.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "esphome/components/select/select.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+#include <algorithm>
+
+namespace esphome {
+namespace select {
+
+class PersistedSelect : public select::Select, public Component {
+ public:
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void setup() override;
+
+ protected:
+  void control(const std::string &value) override;
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace select
+}  // namespace esphome

--- a/components/persisted_switch/__init__.py
+++ b/components/persisted_switch/__init__.py
@@ -1,0 +1,22 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["switch"]
+
+PersistedSwitch = switch.switch_ns.class_(
+    "PersistedSwitch", switch.Switch, cg.Component
+)
+
+PERSISTED_SWITCH_SCHEMA = switch.switch_schema(PersistedSwitch).extend(
+    {
+        cv.GenerateID(): cv.declare_id(PersistedSwitch),
+    }
+)
+
+
+async def new_persisted_switch(config):
+    var = await switch.new_switch(config)
+    await cg.register_component(var, config)
+    return var

--- a/components/persisted_switch/persisted_switch.cpp
+++ b/components/persisted_switch/persisted_switch.cpp
@@ -1,0 +1,22 @@
+#include "persisted_switch.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace switch_ {
+
+void PersistedSwitch::write_state(bool state) {
+  this->publish_state(state);
+  this->pref_.save(&state);
+}
+
+void PersistedSwitch::setup() {
+  this->pref_ = global_preferences->make_preference<bool>(this->get_object_id_hash());
+  bool value{false};
+  if (this->pref_.load(&value)) {
+    ESP_LOGI("switch", "'%s': Restored state %s", this->get_name().c_str(), ONOFF(value));
+  }
+  this->publish_state(value);
+}
+
+}  // namespace switch_
+}  // namespace esphome

--- a/components/persisted_switch/persisted_switch.h
+++ b/components/persisted_switch/persisted_switch.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esphome/components/switch/switch.h"
+#include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
+
+namespace esphome {
+namespace switch_ {
+
+class PersistedSwitch : public switch_::Switch, public Component {
+ public:
+  float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  void setup() override;
+
+ protected:
+  void write_state(bool state) override;
+  ESPPreferenceObject pref_;
+};
+
+}  // namespace switch_
+}  // namespace esphome

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -11,7 +11,15 @@ from esphome.const import (
 from ..vl53l1x import distance_as_mm, NullableSchema, VL53L1X
 
 DEPENDENCIES = ["vl53l1x"]
-AUTO_LOAD = ["vl53l1x", "sensor", "binary_sensor", "text_sensor", "number"]
+AUTO_LOAD = [
+    "vl53l1x",
+    "sensor",
+    "binary_sensor",
+    "text_sensor",
+    "number",
+    "persisted_switch",
+    "persisted_select",
+]
 MULTI_CONF = True
 
 CONF_ROODE_ID = "roode_id"
@@ -37,6 +45,8 @@ CONF_LOG_FALLBACK = "log_fallback_events"
 CONF_FORCE_SINGLE_CORE = "force_single_core"
 CONF_INVALID_DISTANCE_LIMIT = "invalid_distance_limit"
 CONF_RESTART_TIMEOUT = "restart_timeout"
+CONF_REFRESH_MODE = "refresh"
+CONF_CALIBRATION_RANGING = "calibration_ranging"
 
 FilterMode = roode_ns.enum("FilterMode")
 FILTER_MODES = {
@@ -91,10 +101,6 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_CALIBRATION_PERSISTENCE, default=False): cv.boolean,
         cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
         cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
-        cv.Optional(CONF_LOG_FALLBACK, default=False): cv.boolean,
-        cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
-        cv.Optional(CONF_INVALID_DISTANCE_LIMIT, default=10): cv.All(cv.uint8_t, cv.Range(min=1)),
-        cv.Optional(CONF_RESTART_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
                 cv.Optional(CONF_INVERT, default=False): cv.boolean,
@@ -118,10 +124,6 @@ async def to_code(config: Dict):
     cg.add(roode.set_calibration_persistence(config[CONF_CALIBRATION_PERSISTENCE]))
     cg.add(roode.set_filter_mode(config[CONF_FILTER_MODE]))
     cg.add(roode.set_filter_window(config[CONF_FILTER_WINDOW]))
-    cg.add(roode.set_log_fallback_events(config[CONF_LOG_FALLBACK]))
-    cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
-    cg.add(roode.set_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT]))
-    cg.add(roode.set_restart_timeout(config[CONF_RESTART_TIMEOUT]))
     cg.add(roode.set_invert_direction(config[CONF_ZONES][CONF_INVERT]))
     setup_zone(CONF_ENTRY_ZONE, config, roode)
     setup_zone(CONF_EXIT_ZONE, config, roode)

--- a/components/roode/number.py
+++ b/components/roode/number.py
@@ -12,6 +12,24 @@ DEPENDENCIES = ["roode"]
 AUTO_LOAD = ["number", "persisted_number"]
 
 CONF_PEOPLE_COUNTER = "people_counter"
+CONF_INVALID_DISTANCE_LIMIT = "invalid_distance_limit"
+CONF_RESTART_TIMEOUT = "restart_timeout"
+CONF_SAMPLING = "sampling"
+CONF_FILTER_WINDOW = "filter_window"
+CONF_DETECTION_MIN = "detection_threshold_min"
+CONF_DETECTION_MAX = "detection_threshold_max"
+CONF_ENTRY_THRESHOLD_MIN = "entry_threshold_min"
+CONF_ENTRY_THRESHOLD_MAX = "entry_threshold_max"
+CONF_EXIT_THRESHOLD_MIN = "exit_threshold_min"
+CONF_EXIT_THRESHOLD_MAX = "exit_threshold_max"
+CONF_ENTRY_ROI_HEIGHT = "entry_roi_height"
+CONF_EXIT_ROI_HEIGHT = "exit_roi_height"
+CONF_ROI_WIDTH = "roi_width"
+CONF_ROI_HEIGHT = "roi_height"
+CONF_ENTRY_ROI_CENTER = "entry_roi_center"
+CONF_EXIT_ROI_CENTER = "exit_roi_center"
+CONF_CALIBRATION_OFFSET = "calibration_offset"
+CONF_CALIBRATION_CROSSTALK = "calibration_crosstalk"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -22,18 +40,228 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_MAX_VALUE, 10): cv.int_range(-128, 128),
             }
         ),
+        cv.Optional(CONF_INVALID_DISTANCE_LIMIT): PERSISTED_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_ICON, default="mdi:ruler"): cv.icon,
+                cv.Optional(CONF_MAX_VALUE, 100): cv.int_range(1, 100),
+            }
+        ),
+        cv.Optional(CONF_RESTART_TIMEOUT): PERSISTED_NUMBER_SCHEMA.extend(
+            {
+                cv.Optional(CONF_ICON, default="mdi:timer"): cv.icon,
+                cv.Optional(CONF_MAX_VALUE, 120): cv.int_range(1, 120),
+            }
+        ),
+        cv.Optional(CONF_SAMPLING): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 6): cv.int_range(1, 6)}
+        ),
+        cv.Optional(CONF_FILTER_WINDOW): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 9): cv.int_range(3, 9)}
+        ),
+        cv.Optional(CONF_DETECTION_MIN): PERSISTED_NUMBER_SCHEMA,
+        cv.Optional(CONF_DETECTION_MAX): PERSISTED_NUMBER_SCHEMA,
+        cv.Optional(CONF_ENTRY_THRESHOLD_MIN): PERSISTED_NUMBER_SCHEMA,
+        cv.Optional(CONF_ENTRY_THRESHOLD_MAX): PERSISTED_NUMBER_SCHEMA,
+        cv.Optional(CONF_EXIT_THRESHOLD_MIN): PERSISTED_NUMBER_SCHEMA,
+        cv.Optional(CONF_EXIT_THRESHOLD_MAX): PERSISTED_NUMBER_SCHEMA,
+        cv.Optional(CONF_ENTRY_ROI_HEIGHT): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 16): cv.int_range(4, 16)}
+        ),
+        cv.Optional(CONF_EXIT_ROI_HEIGHT): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 16): cv.int_range(4, 16)}
+        ),
+        cv.Optional(CONF_ROI_WIDTH): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 16): cv.int_range(4, 16)}
+        ),
+        cv.Optional(CONF_ROI_HEIGHT): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 16): cv.int_range(4, 16)}
+        ),
+        cv.Optional(CONF_ENTRY_ROI_CENTER): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 255): cv.int_range(0, 255)}
+        ),
+        cv.Optional(CONF_EXIT_ROI_CENTER): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 255): cv.int_range(0, 255)}
+        ),
+        cv.Optional(CONF_CALIBRATION_OFFSET): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 50): cv.int_range(-50, 50)}
+        ),
+        cv.Optional(CONF_CALIBRATION_CROSSTALK): PERSISTED_NUMBER_SCHEMA.extend(
+            {cv.Optional(CONF_MAX_VALUE, 100000): cv.int_range(0, 100000)}
+        ),
     }
 )
 
 
 async def setup_people_counter(config: OrderedDict, hub: MockObj):
     counter = await new_persisted_number(
-        config, min_value=0, step=1, max_value=config[CONF_MAX_VALUE]
+        config, min_value=0, step=1, max_value=config[CONF_MAX_VALUE], default_value=0
     )
     cg.add(hub.set_people_counter(counter))
+
+
+async def setup_invalid_distance_limit(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=1, max_value=config[CONF_MAX_VALUE], step=1, default_value=10
+    )
+    cg.add(hub.set_invalid_distance_limit_number(num))
+
+
+async def setup_restart_timeout(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=1, max_value=config[CONF_MAX_VALUE], step=1, default_value=30
+    )
+    cg.add(hub.set_restart_timeout_number(num))
+
+
+async def setup_sampling(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=1, max_value=config[CONF_MAX_VALUE], step=1, default_value=2
+    )
+    cg.add(hub.set_sampling_number(num))
+
+
+async def setup_filter_window(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=3, max_value=config[CONF_MAX_VALUE], step=2, default_value=5
+    )
+    cg.add(hub.set_filter_window_number(num))
+
+
+async def setup_detection_min(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100, step=1, default_value=0
+    )
+    cg.add(hub.set_detection_min_number(num))
+
+
+async def setup_detection_max(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100, step=1, default_value=85
+    )
+    cg.add(hub.set_detection_max_number(num))
+
+
+async def setup_entry_threshold_min(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100, step=1, default_value=0
+    )
+    cg.add(hub.set_entry_threshold_min_number(num))
+
+
+async def setup_entry_threshold_max(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100, step=1, default_value=85
+    )
+    cg.add(hub.set_entry_threshold_max_number(num))
+
+
+async def setup_exit_threshold_min(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100, step=1, default_value=0
+    )
+    cg.add(hub.set_exit_threshold_min_number(num))
+
+
+async def setup_exit_threshold_max(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100, step=1, default_value=85
+    )
+    cg.add(hub.set_exit_threshold_max_number(num))
+
+
+async def setup_entry_roi_height(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=4, max_value=16, step=1, default_value=16
+    )
+    cg.add(hub.set_entry_roi_height_number(num))
+
+
+async def setup_exit_roi_height(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=4, max_value=16, step=1, default_value=16
+    )
+    cg.add(hub.set_exit_roi_height_number(num))
+
+
+async def setup_roi_width(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=4, max_value=16, step=1, default_value=6
+    )
+    cg.add(hub.set_roi_width_number(num))
+
+
+async def setup_roi_height(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=4, max_value=16, step=1, default_value=16
+    )
+    cg.add(hub.set_roi_height_number(num))
+
+
+async def setup_entry_roi_center(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=255, step=1, default_value=0
+    )
+    cg.add(hub.set_entry_roi_center_number(num))
+
+
+async def setup_exit_roi_center(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=255, step=1, default_value=0
+    )
+    cg.add(hub.set_exit_roi_center_number(num))
+
+
+async def setup_calibration_offset(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=-50, max_value=50, step=1, default_value=0
+    )
+    cg.add(hub.set_calibration_offset_number(num))
+
+
+async def setup_calibration_crosstalk(config: OrderedDict, hub: MockObj):
+    num = await new_persisted_number(
+        config, min_value=0, max_value=100000, step=1000, default_value=0
+    )
+    cg.add(hub.set_calibration_crosstalk_number(num))
 
 
 async def to_code(config: OrderedDict):
     hub = await cg.get_variable(config[CONF_ROODE_ID])
     if CONF_PEOPLE_COUNTER in config:
         await setup_people_counter(config[CONF_PEOPLE_COUNTER], hub)
+    if CONF_INVALID_DISTANCE_LIMIT in config:
+        await setup_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT], hub)
+    if CONF_RESTART_TIMEOUT in config:
+        await setup_restart_timeout(config[CONF_RESTART_TIMEOUT], hub)
+    if CONF_SAMPLING in config:
+        await setup_sampling(config[CONF_SAMPLING], hub)
+    if CONF_FILTER_WINDOW in config:
+        await setup_filter_window(config[CONF_FILTER_WINDOW], hub)
+    if CONF_DETECTION_MIN in config:
+        await setup_detection_min(config[CONF_DETECTION_MIN], hub)
+    if CONF_DETECTION_MAX in config:
+        await setup_detection_max(config[CONF_DETECTION_MAX], hub)
+    if CONF_ENTRY_THRESHOLD_MIN in config:
+        await setup_entry_threshold_min(config[CONF_ENTRY_THRESHOLD_MIN], hub)
+    if CONF_ENTRY_THRESHOLD_MAX in config:
+        await setup_entry_threshold_max(config[CONF_ENTRY_THRESHOLD_MAX], hub)
+    if CONF_EXIT_THRESHOLD_MIN in config:
+        await setup_exit_threshold_min(config[CONF_EXIT_THRESHOLD_MIN], hub)
+    if CONF_EXIT_THRESHOLD_MAX in config:
+        await setup_exit_threshold_max(config[CONF_EXIT_THRESHOLD_MAX], hub)
+    if CONF_ENTRY_ROI_HEIGHT in config:
+        await setup_entry_roi_height(config[CONF_ENTRY_ROI_HEIGHT], hub)
+    if CONF_EXIT_ROI_HEIGHT in config:
+        await setup_exit_roi_height(config[CONF_EXIT_ROI_HEIGHT], hub)
+    if CONF_ROI_WIDTH in config:
+        await setup_roi_width(config[CONF_ROI_WIDTH], hub)
+    if CONF_ROI_HEIGHT in config:
+        await setup_roi_height(config[CONF_ROI_HEIGHT], hub)
+    if CONF_ENTRY_ROI_CENTER in config:
+        await setup_entry_roi_center(config[CONF_ENTRY_ROI_CENTER], hub)
+    if CONF_EXIT_ROI_CENTER in config:
+        await setup_exit_roi_center(config[CONF_EXIT_ROI_CENTER], hub)
+    if CONF_CALIBRATION_OFFSET in config:
+        await setup_calibration_offset(config[CONF_CALIBRATION_OFFSET], hub)
+    if CONF_CALIBRATION_CROSSTALK in config:
+        await setup_calibration_crosstalk(config[CONF_CALIBRATION_CROSSTALK], hub)

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -5,6 +5,10 @@
 #include <vector>
 #include <algorithm>
 #include <ctime>
+#include "esphome/components/number/number.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/select/select.h"
+#include "../vl53l1x/ranging.h"
 
 namespace esphome {
 namespace roode {
@@ -298,8 +302,7 @@ void Roode::loop() {
   } else {
     invalid_read_count_ = 0;
   }
-  if (invalid_read_count_ > invalid_distance_limit_ &&
-      (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
+  if (invalid_read_count_ > invalid_distance_limit_ && (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
     ESP_LOGW(TAG, "Consecutive invalid distances, restarting...");
     restart_sensor();
   }
@@ -525,6 +528,7 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   // thresholds and ROI values immediately after a fail-safe recalibration
   publish_sensor_configuration(entry, exit, true);
   publish_sensor_configuration(entry, exit, false);
+  publish_config_numbers();
   publish_feature_list();
 }
 
@@ -631,6 +635,7 @@ void Roode::calibrate_zones() {
   publish_sensor_configuration(entry, exit, true);
   App.feed_wdt();
   publish_sensor_configuration(entry, exit, false);
+  publish_config_numbers();
 
   calibration_data_[0] = {entry->threshold->idle, entry->threshold->min, entry->threshold->max,
                           static_cast<uint32_t>(time(nullptr))};
@@ -694,6 +699,33 @@ void Roode::publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax) {
   }
 }
 
+void Roode::publish_config_numbers() {
+  if (entry_roi_height_number != nullptr)
+    entry_roi_height_number->publish_state(entry->roi->height);
+  if (exit_roi_height_number != nullptr)
+    exit_roi_height_number->publish_state(exit->roi->height);
+  if (roi_width_number != nullptr)
+    roi_width_number->publish_state(entry->roi->width);
+  if (roi_height_number != nullptr)
+    roi_height_number->publish_state(entry->roi->height);
+  if (entry_roi_center_number != nullptr)
+    entry_roi_center_number->publish_state(entry->roi->center);
+  if (exit_roi_center_number != nullptr)
+    exit_roi_center_number->publish_state(exit->roi->center);
+  if (detection_min_number != nullptr)
+    detection_min_number->publish_state(entry->threshold->min_percentage.value_or(15));
+  if (detection_max_number != nullptr)
+    detection_max_number->publish_state(entry->threshold->max_percentage.value_or(80));
+  if (entry_threshold_min_number != nullptr)
+    entry_threshold_min_number->publish_state(entry->threshold->min_percentage.value_or(15));
+  if (entry_threshold_max_number != nullptr)
+    entry_threshold_max_number->publish_state(entry->threshold->max_percentage.value_or(80));
+  if (exit_threshold_min_number != nullptr)
+    exit_threshold_min_number->publish_state(exit->threshold->min_percentage.value_or(15));
+  if (exit_threshold_max_number != nullptr)
+    exit_threshold_max_number->publish_state(exit->threshold->max_percentage.value_or(80));
+}
+
 void Roode::publish_feature_list() {
   auto fmt_bytes = [](uint32_t bytes) {
     char buf[16];
@@ -750,7 +782,6 @@ void Roode::publish_feature_list() {
   log_event(std::string("features_enabled: ") + feature_list);
 }
 
-
 void Roode::update_status_text(const std::string &status) {
   if (status_text_sensor != nullptr && status != last_status_text_) {
     status_text_sensor->publish_state(status);
@@ -764,13 +795,261 @@ void Roode::restart_sensor() {
   invalid_read_count_ = 0;
 }
 
+void Roode::set_invalid_distance_limit_number(number::Number *num) {
+  this->invalid_distance_limit_number = num;
+  this->invalid_distance_limit_ = static_cast<uint8_t>(num->state);
+  num->add_on_state_callback([this](float value) { this->invalid_distance_limit_ = static_cast<uint8_t>(value); });
+}
+
+void Roode::set_restart_timeout_number(number::Number *num) {
+  this->restart_timeout_number = num;
+  this->restart_timeout_ms_ = static_cast<uint32_t>(num->state) * 1000;
+  num->add_on_state_callback([this](float value) { this->restart_timeout_ms_ = static_cast<uint32_t>(value) * 1000; });
+}
+
+void Roode::set_log_fallback_switch(switch_::Switch *sw) {
+  this->log_fallback_switch = sw;
+  log_fallback_events_ = sw->state;
+  sw->add_on_state_callback([this](bool state) { this->set_log_fallback_events(state); });
+}
+
+void Roode::set_force_single_core_switch(switch_::Switch *sw) {
+  this->force_single_core_switch = sw;
+  force_single_core_ = sw->state;
+  sw->add_on_state_callback([this](bool state) { this->set_force_single_core(state); });
+}
+
+void Roode::set_sampling_number(number::Number *num) {
+  this->sampling_number = num;
+  this->set_sampling_size(static_cast<uint8_t>(num->state));
+  num->add_on_state_callback([this](float value) { this->set_sampling_size(static_cast<uint8_t>(value)); });
+}
+
+void Roode::set_filter_window_number(number::Number *num) {
+  this->filter_window_number = num;
+  this->set_filter_window(static_cast<uint8_t>(num->state));
+  num->add_on_state_callback([this](float value) { this->set_filter_window(static_cast<uint8_t>(value)); });
+}
+
+void Roode::set_detection_min_number(number::Number *num) {
+  this->detection_min_number = num;
+  uint8_t min = static_cast<uint8_t>(num->state);
+  entry->set_threshold_percentages(min, entry->threshold->max_percentage.value_or(80));
+  exit->set_threshold_percentages(min, exit->threshold->max_percentage.value_or(80));
+  num->add_on_state_callback([this](float value) {
+    uint8_t min = static_cast<uint8_t>(value);
+    entry->set_threshold_percentages(min, entry->threshold->max_percentage.value_or(80));
+    exit->set_threshold_percentages(min, exit->threshold->max_percentage.value_or(80));
+  });
+}
+
+void Roode::set_detection_max_number(number::Number *num) {
+  this->detection_max_number = num;
+  uint8_t max = static_cast<uint8_t>(num->state);
+  entry->set_threshold_percentages(entry->threshold->min_percentage.value_or(15), max);
+  exit->set_threshold_percentages(exit->threshold->min_percentage.value_or(15), max);
+  num->add_on_state_callback([this](float value) {
+    uint8_t max = static_cast<uint8_t>(value);
+    entry->set_threshold_percentages(entry->threshold->min_percentage.value_or(15), max);
+    exit->set_threshold_percentages(exit->threshold->min_percentage.value_or(15), max);
+  });
+}
+
+void Roode::set_entry_threshold_min_number(number::Number *num) {
+  this->entry_threshold_min_number = num;
+  uint8_t min = static_cast<uint8_t>(num->state);
+  entry->set_threshold_percentages(min, entry->threshold->max_percentage.value_or(80));
+  num->add_on_state_callback([this](float value) {
+    uint8_t min = static_cast<uint8_t>(value);
+    entry->set_threshold_percentages(min, entry->threshold->max_percentage.value_or(80));
+  });
+}
+
+void Roode::set_entry_threshold_max_number(number::Number *num) {
+  this->entry_threshold_max_number = num;
+  uint8_t max = static_cast<uint8_t>(num->state);
+  entry->set_threshold_percentages(entry->threshold->min_percentage.value_or(15), max);
+  num->add_on_state_callback([this](float value) {
+    uint8_t max = static_cast<uint8_t>(value);
+    entry->set_threshold_percentages(entry->threshold->min_percentage.value_or(15), max);
+  });
+}
+
+void Roode::set_exit_threshold_min_number(number::Number *num) {
+  this->exit_threshold_min_number = num;
+  uint8_t min = static_cast<uint8_t>(num->state);
+  exit->set_threshold_percentages(min, exit->threshold->max_percentage.value_or(80));
+  num->add_on_state_callback([this](float value) {
+    uint8_t min = static_cast<uint8_t>(value);
+    exit->set_threshold_percentages(min, exit->threshold->max_percentage.value_or(80));
+  });
+}
+
+void Roode::set_exit_threshold_max_number(number::Number *num) {
+  this->exit_threshold_max_number = num;
+  uint8_t max = static_cast<uint8_t>(num->state);
+  exit->set_threshold_percentages(exit->threshold->min_percentage.value_or(15), max);
+  num->add_on_state_callback([this](float value) {
+    uint8_t max = static_cast<uint8_t>(value);
+    exit->set_threshold_percentages(exit->threshold->min_percentage.value_or(15), max);
+  });
+}
+
+void Roode::set_entry_roi_height_number(number::Number *num) {
+  this->entry_roi_height_number = num;
+  uint8_t h = static_cast<uint8_t>(num->state);
+  entry->roi->set_height(h);
+  entry->roi_override->height = h;
+  num->add_on_state_callback([this](float value) {
+    uint8_t val = static_cast<uint8_t>(value);
+    entry->roi->set_height(val);
+    entry->roi_override->height = val;
+  });
+}
+
+void Roode::set_exit_roi_height_number(number::Number *num) {
+  this->exit_roi_height_number = num;
+  uint8_t h = static_cast<uint8_t>(num->state);
+  exit->roi->set_height(h);
+  exit->roi_override->height = h;
+  num->add_on_state_callback([this](float value) {
+    uint8_t val = static_cast<uint8_t>(value);
+    exit->roi->set_height(val);
+    exit->roi_override->height = val;
+  });
+}
+
+void Roode::set_roi_width_number(number::Number *num) {
+  this->roi_width_number = num;
+  uint8_t w = static_cast<uint8_t>(num->state);
+  entry->roi->set_width(w);
+  exit->roi->set_width(w);
+  entry->roi_override->width = w;
+  exit->roi_override->width = w;
+  num->add_on_state_callback([this](float value) {
+    uint8_t val = static_cast<uint8_t>(value);
+    entry->roi->set_width(val);
+    exit->roi->set_width(val);
+    entry->roi_override->width = val;
+    exit->roi_override->width = val;
+  });
+}
+
+void Roode::set_roi_height_number(number::Number *num) {
+  this->roi_height_number = num;
+  uint8_t h = static_cast<uint8_t>(num->state);
+  entry->roi->set_height(h);
+  exit->roi->set_height(h);
+  entry->roi_override->height = h;
+  exit->roi_override->height = h;
+  num->add_on_state_callback([this](float value) {
+    uint8_t val = static_cast<uint8_t>(value);
+    entry->roi->set_height(val);
+    exit->roi->set_height(val);
+    entry->roi_override->height = val;
+    exit->roi_override->height = val;
+  });
+}
+
+void Roode::set_entry_roi_center_number(number::Number *num) {
+  this->entry_roi_center_number = num;
+  uint8_t c = static_cast<uint8_t>(num->state);
+  entry->roi->set_center(c);
+  entry->roi_override->center = c;
+  num->add_on_state_callback([this](float value) {
+    uint8_t val = static_cast<uint8_t>(value);
+    entry->roi->set_center(val);
+    entry->roi_override->center = val;
+  });
+}
+
+void Roode::set_exit_roi_center_number(number::Number *num) {
+  this->exit_roi_center_number = num;
+  uint8_t c = static_cast<uint8_t>(num->state);
+  exit->roi->set_center(c);
+  exit->roi_override->center = c;
+  num->add_on_state_callback([this](float value) {
+    uint8_t val = static_cast<uint8_t>(value);
+    exit->roi->set_center(val);
+    exit->roi_override->center = val;
+  });
+}
+
+void Roode::set_calibration_offset_number(number::Number *num) {
+  this->calibration_offset_number = num;
+  distanceSensor->apply_offset(static_cast<int16_t>(num->state));
+  num->add_on_state_callback([this](float value) { distanceSensor->apply_offset(static_cast<int16_t>(value)); });
+}
+
+void Roode::set_calibration_crosstalk_number(number::Number *num) {
+  this->calibration_crosstalk_number = num;
+  distanceSensor->apply_xtalk(static_cast<uint16_t>(num->state));
+  num->add_on_state_callback([this](float value) { distanceSensor->apply_xtalk(static_cast<uint16_t>(value)); });
+}
+
+void Roode::set_ranging_select(select::Select *sel) {
+  this->ranging_select = sel;
+  auto apply = [this](const std::string &value) {
+    const RangingMode *mode = Ranging::Long;
+    if (value == "short")
+      mode = Ranging::Short;
+    else if (value == "medium")
+      mode = Ranging::Medium;
+    else if (value == "long")
+      mode = Ranging::Long;
+    else
+      mode = nullptr;
+    if (mode != nullptr)
+      distanceSensor->set_ranging_mode_override(mode);
+    else
+      distanceSensor->set_ranging_mode_override(nullptr);
+  };
+  apply(sel->state);
+  sel->add_on_state_callback([apply](const std::string &val, size_t) { apply(val); });
+}
+
+void Roode::set_refresh_select(select::Select *sel) {
+  this->refresh_select = sel;
+  auto apply = [this](const std::string &value) {
+    bool force = value == "polling";
+    distanceSensor->set_force_polling(force);
+  };
+  apply(sel->state);
+  sel->add_on_state_callback([apply](const std::string &val, size_t) { apply(val); });
+}
+
+void Roode::set_filter_mode_select(select::Select *sel) {
+  this->filter_mode_select = sel;
+  auto apply = [this](const std::string &value) {
+    FilterMode mode = FILTER_MIN;
+    if (value == "median")
+      mode = FILTER_MEDIAN;
+    else if (value == "percentile10")
+      mode = FILTER_PERCENTILE10;
+    this->set_filter_mode(mode);
+  };
+  apply(sel->state);
+  sel->add_on_state_callback([apply](const std::string &val, size_t) { apply(val); });
+}
+
+void Roode::set_calibration_persistence_switch(switch_::Switch *sw) {
+  this->calibration_persistence_switch = sw;
+  this->set_calibration_persistence(sw->state);
+  sw->add_on_state_callback([this](bool state) { this->set_calibration_persistence(state); });
+}
+
+void Roode::set_invert_direction_switch(switch_::Switch *sw) {
+  this->invert_direction_switch = sw;
+  this->set_invert_direction(sw->state);
+  sw->add_on_state_callback([this](bool state) { this->set_invert_direction(state); });
+}
+
 void Roode::sensor_task(void *param) {
   auto *self = static_cast<Roode *>(param);
   for (;;) {
     self->use_sensor_task_ = true;
     uint32_t now = millis();
-    if (self->last_loop_update_ts_ != 0 &&
-        (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
+    if (self->last_loop_update_ts_ != 0 && (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
         (now - self->last_sensor_restart_ts_ > self->restart_timeout_ms_)) {
       ESP_LOGW(TAG, "Sensor unresponsive >%ds, restarting...", self->restart_timeout_ms_ / 1000);
       self->restart_sensor();

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -6,6 +6,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/select/select.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
@@ -129,6 +130,31 @@ class Roode : public PollingComponent {
   }
   void set_invalid_distance_limit(uint8_t limit) { invalid_distance_limit_ = limit; }
   void set_restart_timeout(uint32_t ms) { restart_timeout_ms_ = ms; }
+  void set_invalid_distance_limit_number(number::Number *num);
+  void set_restart_timeout_number(number::Number *num);
+  void set_detection_min_number(number::Number *num);
+  void set_detection_max_number(number::Number *num);
+  void set_entry_threshold_min_number(number::Number *num);
+  void set_entry_threshold_max_number(number::Number *num);
+  void set_exit_threshold_min_number(number::Number *num);
+  void set_exit_threshold_max_number(number::Number *num);
+  void set_entry_roi_height_number(number::Number *num);
+  void set_exit_roi_height_number(number::Number *num);
+  void set_roi_width_number(number::Number *num);
+  void set_roi_height_number(number::Number *num);
+  void set_entry_roi_center_number(number::Number *num);
+  void set_exit_roi_center_number(number::Number *num);
+  void set_calibration_offset_number(number::Number *num);
+  void set_calibration_crosstalk_number(number::Number *num);
+  void set_ranging_select(select::Select *sel);
+  void set_refresh_select(select::Select *sel);
+  void set_log_fallback_switch(switch_::Switch *sw);
+  void set_force_single_core_switch(switch_::Switch *sw);
+  void set_sampling_number(number::Number *num);
+  void set_filter_window_number(number::Number *num);
+  void set_filter_mode_select(select::Select *sel);
+  void set_calibration_persistence_switch(switch_::Switch *sw);
+  void set_invert_direction_switch(switch_::Switch *sw);
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
   void set_entry_threshold_percentages(uint8_t min, uint8_t max) { entry->set_threshold_percentages(min, max); }
@@ -146,6 +172,31 @@ class Roode : public PollingComponent {
   sensor::Sensor *distance_entry{nullptr};
   sensor::Sensor *distance_exit{nullptr};
   number::Number *people_counter{nullptr};
+  number::Number *invalid_distance_limit_number{nullptr};
+  number::Number *restart_timeout_number{nullptr};
+  number::Number *sampling_number{nullptr};
+  number::Number *filter_window_number{nullptr};
+  number::Number *detection_min_number{nullptr};
+  number::Number *detection_max_number{nullptr};
+  number::Number *entry_threshold_min_number{nullptr};
+  number::Number *entry_threshold_max_number{nullptr};
+  number::Number *exit_threshold_min_number{nullptr};
+  number::Number *exit_threshold_max_number{nullptr};
+  number::Number *entry_roi_height_number{nullptr};
+  number::Number *exit_roi_height_number{nullptr};
+  number::Number *roi_width_number{nullptr};
+  number::Number *roi_height_number{nullptr};
+  number::Number *entry_roi_center_number{nullptr};
+  number::Number *exit_roi_center_number{nullptr};
+  number::Number *calibration_offset_number{nullptr};
+  number::Number *calibration_crosstalk_number{nullptr};
+  switch_::Switch *log_fallback_switch{nullptr};
+  switch_::Switch *force_single_core_switch{nullptr};
+  switch_::Switch *calibration_persistence_switch{nullptr};
+  switch_::Switch *invert_direction_switch{nullptr};
+  select::Select *filter_mode_select{nullptr};
+  select::Select *ranging_select{nullptr};
+  select::Select *refresh_select{nullptr};
   sensor::Sensor *max_threshold_entry_sensor{nullptr};
   sensor::Sensor *max_threshold_exit_sensor{nullptr};
   sensor::Sensor *min_threshold_entry_sensor{nullptr};
@@ -214,6 +265,7 @@ class Roode : public PollingComponent {
   void publish_feature_list();
   const RangingMode *determine_ranging_mode(uint16_t average_entry_zone_distance, uint16_t average_exit_zone_distance);
   void publish_sensor_configuration(Zone *entry, Zone *exit, bool isMax);
+  void publish_config_numbers();
   void updateCounter(int delta);
   Orientation orientation_{Parallel};
   uint8_t samples{2};

--- a/components/roode/select.py
+++ b/components/roode/select.py
@@ -1,0 +1,70 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import select
+
+from ..persisted_select import PERSISTED_SELECT_SCHEMA, new_persisted_select
+from . import (
+    Roode,
+    CONF_ROODE_ID,
+    CONF_FILTER_MODE,
+    FILTER_MODES,
+    CONF_REFRESH_MODE,
+    CONF_CALIBRATION_RANGING,
+)
+
+DEPENDENCIES = ["roode"]
+AUTO_LOAD = ["select", "persisted_select"]
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
+        cv.Optional(CONF_FILTER_MODE): PERSISTED_SELECT_SCHEMA.extend(
+            {
+                cv.Optional(
+                    "options", default=list(FILTER_MODES.keys())
+                ): cv.ensure_list(cv.one_of(*FILTER_MODES.keys(), lower=True))
+            }
+        ),
+        cv.Optional(CONF_CALIBRATION_RANGING): PERSISTED_SELECT_SCHEMA.extend(
+            {
+                cv.Optional(
+                    "options", default=["auto", "short", "medium", "long"]
+                ): cv.ensure_list(
+                    cv.one_of("auto", "short", "medium", "long", lower=True)
+                )
+            }
+        ),
+        cv.Optional(CONF_REFRESH_MODE): PERSISTED_SELECT_SCHEMA.extend(
+            {
+                cv.Optional(
+                    "options", default=["interrupt", "polling"]
+                ): cv.ensure_list(cv.one_of("interrupt", "polling", lower=True))
+            }
+        ),
+    }
+)
+
+
+async def setup_filter_mode(config, hub):
+    sel = await new_persisted_select(config)
+    cg.add(hub.set_filter_mode_select(sel))
+
+
+async def setup_ranging(config, hub):
+    sel = await new_persisted_select(config)
+    cg.add(hub.set_ranging_select(sel))
+
+
+async def setup_refresh(config, hub):
+    sel = await new_persisted_select(config)
+    cg.add(hub.set_refresh_select(sel))
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_ROODE_ID])
+    if CONF_FILTER_MODE in config:
+        await setup_filter_mode(config[CONF_FILTER_MODE], hub)
+    if CONF_CALIBRATION_RANGING in config:
+        await setup_ranging(config[CONF_CALIBRATION_RANGING], hub)
+    if CONF_REFRESH_MODE in config:
+        await setup_refresh(config[CONF_REFRESH_MODE], hub)

--- a/components/roode/switch.py
+++ b/components/roode/switch.py
@@ -1,0 +1,56 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+
+from ..persisted_switch import PERSISTED_SWITCH_SCHEMA, new_persisted_switch
+from . import Roode, CONF_ROODE_ID
+
+DEPENDENCIES = ["roode"]
+AUTO_LOAD = ["switch", "persisted_switch"]
+
+CONF_LOG_FALLBACK = "log_fallback_events"
+CONF_FORCE_SINGLE_CORE = "force_single_core"
+CONF_CALIBRATION_PERSISTENCE = "calibration_persistence"
+CONF_ZONES_INVERT = "zones_invert"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
+        cv.Optional(CONF_LOG_FALLBACK): PERSISTED_SWITCH_SCHEMA,
+        cv.Optional(CONF_FORCE_SINGLE_CORE): PERSISTED_SWITCH_SCHEMA,
+        cv.Optional(CONF_CALIBRATION_PERSISTENCE): PERSISTED_SWITCH_SCHEMA,
+        cv.Optional(CONF_ZONES_INVERT): PERSISTED_SWITCH_SCHEMA,
+    }
+)
+
+
+async def setup_log_fallback(config, hub):
+    sw = await new_persisted_switch(config)
+    cg.add(hub.set_log_fallback_switch(sw))
+
+
+async def setup_force_single_core(config, hub):
+    sw = await new_persisted_switch(config)
+    cg.add(hub.set_force_single_core_switch(sw))
+
+
+async def setup_calibration_persistence(config, hub):
+    sw = await new_persisted_switch(config)
+    cg.add(hub.set_calibration_persistence_switch(sw))
+
+
+async def setup_zones_invert(config, hub):
+    sw = await new_persisted_switch(config)
+    cg.add(hub.set_invert_direction_switch(sw))
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_ROODE_ID])
+    if CONF_LOG_FALLBACK in config:
+        await setup_log_fallback(config[CONF_LOG_FALLBACK], hub)
+    if CONF_FORCE_SINGLE_CORE in config:
+        await setup_force_single_core(config[CONF_FORCE_SINGLE_CORE], hub)
+    if CONF_CALIBRATION_PERSISTENCE in config:
+        await setup_calibration_persistence(config[CONF_CALIBRATION_PERSISTENCE], hub)
+    if CONF_ZONES_INVERT in config:
+        await setup_zones_invert(config[CONF_ZONES_INVERT], hub)

--- a/components/vl53l1x/roi.h
+++ b/components/vl53l1x/roi.h
@@ -4,9 +4,9 @@ namespace esphome {
 namespace vl53l1x {
 
 struct ROI {
-  uint8_t width;
-  uint8_t height;
-  uint8_t center;
+  uint8_t width{0};
+  uint8_t height{0};
+  uint8_t center{0};
   void set_width(uint8_t val) { this->width = val; }
   void set_height(uint8_t val) { this->height = val; }
   void set_center(uint8_t val) { this->center = val; }

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -59,7 +59,7 @@ void VL53L1X::setup() {
     delay(2);
   }
 
-  if (this->interrupt_pin.has_value()) {
+  if (this->interrupt_pin.has_value() && !force_polling_) {
     this->interrupt_pin.value()->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
     this->interrupt_pin.value()->setup();
     ESP_LOGD(TAG, "Interrupt pin configured");
@@ -246,7 +246,7 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
 
   // Decide whether we can use the interrupt pin for this reading
   uint8_t dataReady = false;
-  bool use_int = is_interrupt_enabled();
+  bool use_int = is_interrupt_enabled() && !force_polling_;
   if (!use_int && this->interrupt_pin.has_value() &&
       (millis() - last_interrupt_retry_ >= 1800000UL)) {
     if (validate_interrupt()) {
@@ -505,6 +505,20 @@ void VL53L1X::record_failure() {
     ESP_LOGW(TAG, "10 read errors — triggering recovery");
     soft_reset();
     consecutive_failures_ = 0;
+  }
+}
+
+void VL53L1X::apply_offset(int16_t val) {
+  this->offset = val;
+  if (!this->is_failed()) {
+    this->sensor.SetOffsetInMm(val);
+  }
+}
+
+void VL53L1X::apply_xtalk(uint16_t val) {
+  this->xtalk = val;
+  if (!this->is_failed()) {
+    this->sensor.SetXTalk(val);
   }
 }
 

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -51,7 +51,11 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   void set_ranging_mode_override(const RangingMode *mode) { this->ranging_mode_override = {mode}; }
   void set_offset(int16_t val) { this->offset = val; }
   void set_xtalk(uint16_t val) { this->xtalk = val; }
+  void apply_offset(int16_t val);
+  void apply_xtalk(uint16_t val);
   void set_timeout(uint16_t val) { this->timeout = val; }
+  void set_force_polling(bool force) { this->force_polling_ = force; }
+  bool is_force_polling() const { return force_polling_; }
 
   bool is_interrupt_enabled() const { return interrupt_active_ && interrupt_pin.has_value(); }
 
@@ -89,6 +93,7 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   uint8_t interrupt_miss_count_{0};
   uint32_t last_interrupt_retry_{0};
   uint8_t consecutive_failures_{0};
+  bool force_polling_{false};
 };
 
 }  // namespace vl53l1x


### PR DESCRIPTION
## Summary
- create PersistedSwitch, PersistedSelect, and PersistedNumber helpers
- expose configuration numbers, selects and switches under the Roode platform
- document how to add these entities with a copy‑and‑paste YAML example
- use step of 2 for the filter_window input number
- fix ROI entity handlers so changes persist across recalibration

## Testing
- `esphome config ci/esp32.yaml`
- `esphome compile ci/esp32.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68882e3faf3c8330bbb42ee45a952b3b