### PR TITLE
Fix zone calibration null pointer issue

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -616,6 +616,15 @@ const RangingMode *Roode::determine_ranging_mode(uint16_t average_entry_zone_dis
 }
 
 void Roode::calibrate_zones() {
+  if (entry == nullptr || exit == nullptr || distanceSensor == nullptr) {
+    ESP_LOGE(SETUP, "Cannot calibrate zones - uninitialized pointers");
+    return;
+  }
+  if (entry->roi == nullptr || entry->threshold == nullptr || exit->roi == nullptr ||
+      exit->threshold == nullptr) {
+    ESP_LOGE(SETUP, "Cannot calibrate zones - zone configuration missing");
+    return;
+  }
   ESP_LOGI(SETUP, "Calibrating sensor zones");
 
   entry->reset_roi(orientation_ == Parallel ? 167 : 195);


### PR DESCRIPTION
## Summary
- guard against null zone pointers in `calibrate_zones`
- avoid Guru Meditation crashes when sensor configuration hasn't been initialized

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688983da532883309d03e67eaa645a1d