### PR TITLE
Add switches for runtime configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,11 @@ reflections cause false triggers.
 | `roode.zones.invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | `zones: { invert: false }` | `zones: { invert: true }` |
 | `roode.zones.entry/exit` | Optional | none | Per-zone ROI and thresholds | Uneven hallway or obstacles | Tweak each zone separately as needed | *(not set)* | `zones:`<br>`  exit:`<br>`    roi:`<br>`      height: 8` |
 
+Roode also exposes switches for `log_fallback_events`, `force_single_core`,
+`calibration_persistence` and `zones.invert`. These switches default to the values
+configured above and keep their state across reboots so you can toggle the
+behavior from Home Assistant without editing YAML.
+
 
 ### Example Configurations
 

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -1,6 +1,14 @@
 substitutions:
   devicename: roode32
   friendly_name: $devicename
+  log_fallback_events: "false"
+  log_fallback_restore_mode: "RESTORE_DEFAULT_OFF"
+  force_single_core: "false"
+  force_single_core_restore_mode: "RESTORE_DEFAULT_OFF"
+  calibration_persistence: "false"
+  calibration_persistence_restore_mode: "RESTORE_DEFAULT_OFF"
+  zones_invert: "true"
+  zones_invert_restore_mode: "RESTORE_DEFAULT_ON"
 
 external_components:
   refresh: always
@@ -11,6 +19,14 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: |-
+          id(roode_platform)->set_log_fallback_events(id(roode_log_fallback_events).state);
+          id(roode_platform)->set_force_single_core(id(roode_force_single_core).state);
+          id(roode_platform)->set_calibration_persistence(id(roode_calibration_persistence).state);
+          id(roode_platform)->set_invert_direction(id(roode_zones_invert).state);
 
 esp32:
   board: wemos_d1_mini32
@@ -74,6 +90,9 @@ roode:
   id: roode_platform
   # Smooth out measurements by using the minimum distance from this number of readings
   sampling: 2
+  log_fallback_events: ${log_fallback_events}
+  force_single_core: ${force_single_core}
+  calibration_persistence: ${calibration_persistence}
   # This controls the size of the Region of Interest the sensor should take readings in.
   roi: { height: 16, width: 6 }
   # The detection thresholds for determining whether a measurement should count as a person crossing.
@@ -86,7 +105,7 @@ roode:
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:
-    invert: true
+    invert: ${zones_invert}
 
 button:
   - platform: restart
@@ -111,6 +130,40 @@ binary_sensor:
       name: $friendly_name presence
     sensor_xshut_state:
       name: $friendly_name xshut state
+
+switch:
+  - platform: template
+    name: $friendly_name log fallback events
+    id: roode_log_fallback_events
+    restore_mode: ${log_fallback_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(false);
+  - platform: template
+    name: $friendly_name force single core
+    id: roode_force_single_core
+    restore_mode: ${force_single_core_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_force_single_core(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_force_single_core(false);
+  - platform: template
+    name: $friendly_name calibration persistence
+    id: roode_calibration_persistence
+    restore_mode: ${calibration_persistence_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(false);
+  - platform: template
+    name: $friendly_name invert zones
+    id: roode_zones_invert
+    restore_mode: ${zones_invert_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_invert_direction(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_invert_direction(false);
 
 sensor:
   - platform: roode

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -1,6 +1,14 @@
 substitutions:
   devicename: roode32dev
   friendly_name: $devicename
+  log_fallback_events: "false"
+  log_fallback_restore_mode: "RESTORE_DEFAULT_OFF"
+  force_single_core: "false"
+  force_single_core_restore_mode: "RESTORE_DEFAULT_OFF"
+  calibration_persistence: "false"
+  calibration_persistence_restore_mode: "RESTORE_DEFAULT_OFF"
+  zones_invert: "true"
+  zones_invert_restore_mode: "RESTORE_DEFAULT_ON"
 
 external_components:
   refresh: always
@@ -8,6 +16,14 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: |-
+          id(roode_platform)->set_log_fallback_events(id(roode_log_fallback_events).state);
+          id(roode_platform)->set_force_single_core(id(roode_force_single_core).state);
+          id(roode_platform)->set_calibration_persistence(id(roode_calibration_persistence).state);
+          id(roode_platform)->set_invert_direction(id(roode_zones_invert).state);
 
 esp32:
   board: wemos_d1_mini32
@@ -71,6 +87,9 @@ roode:
   # I removed the { size: 1 } option here since it was redundant.
   # Can always add back later if we have more sampling paramaters.
   sampling: 2
+  log_fallback_events: ${log_fallback_events}
+  force_single_core: ${force_single_core}
+  calibration_persistence: ${calibration_persistence}
   # defaults for both zones
   roi:
     # height: 14
@@ -79,7 +98,7 @@ roode:
     # min: 234mm # absolute distance
     max: 85% # percent based on idle distance
   zones:
-    invert: true
+    invert: ${zones_invert}
     entry:
       roi: auto 
     exit:
@@ -114,6 +133,40 @@ binary_sensor:
       name: $friendly_name presence
     sensor_xshut_state:
       name: $friendly_name xshut state
+switch:
+  - platform: template
+    name: $friendly_name log fallback events
+    id: roode_log_fallback_events
+    restore_mode: ${log_fallback_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(false);
+  - platform: template
+    name: $friendly_name force single core
+    id: roode_force_single_core
+    restore_mode: ${force_single_core_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_force_single_core(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_force_single_core(false);
+  - platform: template
+    name: $friendly_name calibration persistence
+    id: roode_calibration_persistence
+    restore_mode: ${calibration_persistence_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(false);
+  - platform: template
+    name: $friendly_name invert zones
+    id: roode_zones_invert
+    restore_mode: ${zones_invert_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_invert_direction(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_invert_direction(false);
+
 
 sensor:
   - platform: roode

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -1,6 +1,14 @@
 substitutions:
   devicename: roode8266
   friendly_name: $devicename
+  log_fallback_events: "false"
+  log_fallback_restore_mode: "RESTORE_DEFAULT_OFF"
+  force_single_core: "false"
+  force_single_core_restore_mode: "RESTORE_DEFAULT_OFF"
+  calibration_persistence: "false"
+  calibration_persistence_restore_mode: "RESTORE_DEFAULT_OFF"
+  zones_invert: "true"
+  zones_invert_restore_mode: "RESTORE_DEFAULT_ON"
 
 external_components:
   refresh: always
@@ -11,6 +19,14 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: |-
+          id(roode_platform)->set_log_fallback_events(id(roode_log_fallback_events).state);
+          id(roode_platform)->set_force_single_core(id(roode_force_single_core).state);
+          id(roode_platform)->set_calibration_persistence(id(roode_calibration_persistence).state);
+          id(roode_platform)->set_invert_direction(id(roode_zones_invert).state);
   platform: ESP8266
   board: d1_mini
 
@@ -71,6 +87,9 @@ roode:
   id: roode_platform
   # Smooth out measurements by using the minimum distance from this number of readings
   sampling: 2
+  log_fallback_events: ${log_fallback_events}
+  force_single_core: ${force_single_core}
+  calibration_persistence: ${calibration_persistence}
   # This controls the size of the Region of Interest the sensor should take readings in.
   roi: { height: 16, width: 6 }
   # The detection thresholds for determining whether a measurement should count as a person crossing.
@@ -83,7 +102,7 @@ roode:
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:
-    invert: true
+    invert: ${zones_invert}
 
 button:
   - platform: restart
@@ -109,6 +128,40 @@ binary_sensor:
       name: $friendly_name presence
     sensor_xshut_state:
       name: $friendly_name xshut state
+switch:
+  - platform: template
+    name: $friendly_name log fallback events
+    id: roode_log_fallback_events
+    restore_mode: ${log_fallback_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(false);
+  - platform: template
+    name: $friendly_name force single core
+    id: roode_force_single_core
+    restore_mode: ${force_single_core_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_force_single_core(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_force_single_core(false);
+  - platform: template
+    name: $friendly_name calibration persistence
+    id: roode_calibration_persistence
+    restore_mode: ${calibration_persistence_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(false);
+  - platform: template
+    name: $friendly_name invert zones
+    id: roode_zones_invert
+    restore_mode: ${zones_invert_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_invert_direction(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_invert_direction(false);
+
 
 sensor:
   - platform: roode

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -1,6 +1,14 @@
 substitutions:
   devicename: roode8266dev
   friendly_name: $devicename
+  log_fallback_events: "false"
+  log_fallback_restore_mode: "RESTORE_DEFAULT_OFF"
+  force_single_core: "false"
+  force_single_core_restore_mode: "RESTORE_DEFAULT_OFF"
+  calibration_persistence: "false"
+  calibration_persistence_restore_mode: "RESTORE_DEFAULT_OFF"
+  zones_invert: "true"
+  zones_invert_restore_mode: "RESTORE_DEFAULT_ON"
 
 external_components:
   refresh: always
@@ -12,6 +20,14 @@ esphome:
   board: d1_mini
 
 wifi:
+  on_boot:
+    priority: 600
+    then:
+      - lambda: |-
+          id(roode_platform)->set_log_fallback_events(id(roode_log_fallback_events).state);
+          id(roode_platform)->set_force_single_core(id(roode_force_single_core).state);
+          id(roode_platform)->set_calibration_persistence(id(roode_calibration_persistence).state);
+          id(roode_platform)->set_invert_direction(id(roode_zones_invert).state);
   networks:
     - ssid: !secret ssid1
       password: !secret ssid1_password
@@ -67,6 +83,9 @@ roode:
   # I removed the { size: 1 } option here since it was redundant.
   # Can always add back later if we have more sampling paramaters.
   sampling: 1
+  log_fallback_events: ${log_fallback_events}
+  force_single_core: ${force_single_core}
+  calibration_persistence: ${calibration_persistence}
   # defaults for both zones
   roi:
     # height: 14
@@ -75,7 +94,7 @@ roode:
     # min: 234mm # absolute distance
     max: 85% # percent based on idle distance
   zones:
-    invert: true
+    invert: ${zones_invert}
     entry:
       roi: auto
     exit:
@@ -110,6 +129,40 @@ binary_sensor:
       name: $friendly_name presence
     sensor_xshut_state:
       name: $friendly_name xshut state
+switch:
+  - platform: template
+    name: $friendly_name log fallback events
+    id: roode_log_fallback_events
+    restore_mode: ${log_fallback_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_log_fallback_events(false);
+  - platform: template
+    name: $friendly_name force single core
+    id: roode_force_single_core
+    restore_mode: ${force_single_core_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_force_single_core(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_force_single_core(false);
+  - platform: template
+    name: $friendly_name calibration persistence
+    id: roode_calibration_persistence
+    restore_mode: ${calibration_persistence_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_calibration_persistence(false);
+  - platform: template
+    name: $friendly_name invert zones
+    id: roode_zones_invert
+    restore_mode: ${zones_invert_restore_mode}
+    turn_on_action:
+      - lambda: id(roode_platform)->set_invert_direction(true);
+    turn_off_action:
+      - lambda: id(roode_platform)->set_invert_direction(false);
+
 
 sensor:
   - platform: roode


### PR DESCRIPTION
## Summary
- expose switch entities for log fallback events, single-core mode, calibration persistence, and zone inversion
- sync Roode settings from switch state on boot
- document new switches

## Testing
- `esphome compile peopleCounter32.yaml` *(fails: `'ota' requires a 'platform' key`)*

------
https://chatgpt.com/codex/tasks/task_e_6889837719b0833085cafcdf399fbe55