### PR TITLE
feat: add vl53l1x sensor package

### DIFF
--- a/components/vl53l1x/sensor/__init__.py
+++ b/components/vl53l1x/sensor/__init__.py
@@ -1,0 +1,22 @@
+"""VL53L1X distance sensor platform."""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    ICON_RULER,
+    STATE_CLASS_MEASUREMENT,
+)
+
+DEPENDENCIES = ["vl53l1x"]
+
+CONFIG_SCHEMA = sensor.sensor_schema(
+    unit_of_measurement="mm",
+    icon=ICON_RULER,
+    accuracy_decimals=0,
+    state_class=STATE_CLASS_MEASUREMENT,
+).extend(cv.COMPONENT_SCHEMA)
+
+
+async def to_code(config):
+    await sensor.new_sensor(config)


### PR DESCRIPTION
## Summary
- move vl53l1x sensor platform into dedicated package so it can be imported as `esphome.components.vl53l1x.sensor`

## Testing
- `esphome config peopleCounter32.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68ab4785a0a48330822d2bc1fee0a6af