### PR TITLE
Replace GNU ?: shorthand in zone.cpp

### DIFF
--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -65,9 +65,9 @@ VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {
  * This is needed to do initial calibration of thresholds & ROI.
  */
 void Zone::reset_roi(uint8_t default_center) {
-  roi->width = roi_override->width ?: 6;
-  roi->height = roi_override->height ?: 16;
-  roi->center = roi_override->center ?: default_center;
+  roi->width = roi_override->width ? roi_override->width : 6;
+  roi->height = roi_override->height ? roi_override->height : 16;
+  roi->center = roi_override->center ? roi_override->center : default_center;
   ESP_LOGD(TAG, "%s ROI reset: { width: %d, height: %d, center: %d }", id == 0U ? "Entry" : "Exit", roi->width,
            roi->height, roi->center);
 }
@@ -111,8 +111,8 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
   // center of the two zones
   int function_of_the_distance = 16 * (1 - (0.15 * 2) / (0.34 * (min(entry_threshold, exit_threshold) / 1000)));
   int ROI_size = min(8, max(4, function_of_the_distance));
-  this->roi->width = this->roi_override->width ?: ROI_size;
-  this->roi->height = this->roi_override->height ?: ROI_size * 2;
+  this->roi->width = this->roi_override->width ? this->roi_override->width : ROI_size;
+  this->roi->height = this->roi_override->height ? this->roi_override->height : ROI_size * 2;
   if (this->roi_override->center) {
     this->roi->center = this->roi_override->center;
   } else {


### PR DESCRIPTION
## Summary
- replace GNU `expr ?: fallback` with explicit `expr ? expr : fallback` in zone logic

## Testing
- `esphome compile /tmp/minimal.yaml` *(fails: 'EDistanceMode' has not been declared)*

------
https://chatgpt.com/codex/tasks/task_e_68ab478ad9408330abe3cdb059c6cb51