### PR TITLE
Expose zone presence sensors for Roode

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ binary_sensor:
       name: $friendly_name presence
     sensor_xshut_state:
       name: $friendly_name xshut state
+    zones:
+      entry:
+        presence:
+          name: $friendly_name entry occupied
+      exit:
+        presence:
+          name: $friendly_name exit occupied
 
 sensor:
   - platform: roode
@@ -454,6 +461,8 @@ calibration:6:01PM
 | `people_counter` | number | Adjustable tally of detected people |
 | `presence` | binary_sensor | True while movement is detected |
 | `sensor_xshut_state` | binary_sensor | Current level of the XSHUT power pin |
+| `zones.entry.presence` | binary_sensor | Entry zone currently occupied |
+| `zones.exit.presence` | binary_sensor | Exit zone currently occupied |
 | `distance_entry` | sensor | Measured distance in the entry zone |
 | `distance_exit` | sensor | Measured distance in the exit zone |
 | `max_threshold_entry` | sensor | Upper detection threshold for entry zone |

--- a/components/roode/binary_sensor.py
+++ b/components/roode/binary_sensor.py
@@ -13,6 +13,9 @@ DEPENDENCIES = ["roode"]
 
 CONF_PRESENCE = "presence"
 CONF_XSHUT_STATE = "sensor_xshut_state"
+CONF_ZONES = "zones"
+CONF_ENTRY = "entry"
+CONF_EXIT = "exit"
 TYPES = [CONF_PRESENCE, CONF_XSHUT_STATE]
 
 CONFIG_SCHEMA = cv.Schema(
@@ -30,6 +33,36 @@ CONFIG_SCHEMA = cv.Schema(
         ).extend(
             {
                 cv.GenerateID(): cv.declare_id(binary_sensor.BinarySensor),
+            }
+        ),
+        cv.Optional(CONF_ZONES): cv.Schema(
+            {
+                cv.Optional(CONF_ENTRY): cv.Schema(
+                    {
+                        cv.Optional(CONF_PRESENCE): binary_sensor.binary_sensor_schema(
+                            binary_sensor.BinarySensor
+                        ).extend(
+                            {
+                                cv.GenerateID(): cv.declare_id(
+                                    binary_sensor.BinarySensor
+                                ),
+                            }
+                        )
+                    }
+                ),
+                cv.Optional(CONF_EXIT): cv.Schema(
+                    {
+                        cv.Optional(CONF_PRESENCE): binary_sensor.binary_sensor_schema(
+                            binary_sensor.BinarySensor
+                        ).extend(
+                            {
+                                cv.GenerateID(): cv.declare_id(
+                                    binary_sensor.BinarySensor
+                                ),
+                            }
+                        )
+                    }
+                ),
             }
         ),
     }
@@ -63,3 +96,15 @@ async def to_code(config):
     hub = await cg.get_variable(config[CONF_ROODE_ID])
     for key in TYPES:
         await setup_conf(config, key, hub)
+    if CONF_ZONES in config:
+        zones = config[CONF_ZONES]
+        if CONF_ENTRY in zones and CONF_PRESENCE in zones[CONF_ENTRY]:
+            conf = zones[CONF_ENTRY][CONF_PRESENCE]
+            sens = cg.new_Pvariable(conf[CONF_ID])
+            await binary_sensor.register_binary_sensor(sens, conf)
+            cg.add(hub.set_entry_presence_binary_sensor(sens))
+        if CONF_EXIT in zones and CONF_PRESENCE in zones[CONF_EXIT]:
+            conf = zones[CONF_EXIT][CONF_PRESENCE]
+            sens = cg.new_Pvariable(conf[CONF_ID])
+            await binary_sensor.register_binary_sensor(sens, conf)
+            cg.add(hub.set_exit_presence_binary_sensor(sens))

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -301,8 +301,7 @@ void Roode::loop() {
   } else {
     invalid_read_count_ = 0;
   }
-  if (invalid_read_count_ > invalid_distance_limit_ &&
-      (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
+  if (invalid_read_count_ > invalid_distance_limit_ && (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
     ESP_LOGW(TAG, "Consecutive invalid distances, restarting...");
     restart_sensor();
   }
@@ -377,11 +376,23 @@ void Roode::path_tracking(Zone *zone) {
     if (presence_sensor != nullptr) {
       presence_sensor->publish_state(true);
     }
+    if (zone->id == 0 && entry_presence_sensor != nullptr) {
+      entry_presence_sensor->publish_state(true);
+    }
+    if (zone->id == 1 && exit_presence_sensor != nullptr) {
+      exit_presence_sensor->publish_state(true);
+    }
     if (zone_triggered_start_[zone->id] == 0) {
       zone_triggered_start_[zone->id] = millis();
     }
   }
   if (CurrentZoneStatus == NOBODY) {
+    if (zone->id == 0 && entry_presence_sensor != nullptr) {
+      entry_presence_sensor->publish_state(false);
+    }
+    if (zone->id == 1 && exit_presence_sensor != nullptr) {
+      exit_presence_sensor->publish_state(false);
+    }
     zone_triggered_start_[zone->id] = 0;
   } else if (zone_triggered_start_[zone->id] != 0 && millis() - zone_triggered_start_[zone->id] >= 10000 &&
              millis() - last_valid_crossing_ts_ >= 120000) {
@@ -753,7 +764,6 @@ void Roode::publish_feature_list() {
   log_event(std::string("features_enabled: ") + feature_list);
 }
 
-
 void Roode::update_status_text(const std::string &status) {
   if (status_text_sensor != nullptr && status != last_status_text_) {
     status_text_sensor->publish_state(status);
@@ -778,8 +788,7 @@ void Roode::sensor_task(void *param) {
 #endif
     self->use_sensor_task_ = true;
     uint32_t now = millis();
-    if (self->last_loop_update_ts_ != 0 &&
-        (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
+    if (self->last_loop_update_ts_ != 0 && (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
         (now - self->last_sensor_restart_ts_ > self->restart_timeout_ms_)) {
       ESP_LOGW(TAG, "Sensor unresponsive >%ds, restarting...", self->restart_timeout_ms_ / 1000);
       self->restart_sensor();

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -99,9 +99,9 @@ class Roode : public PollingComponent {
   void set_cpu_usage_sensor(sensor::Sensor *sens) { cpu_usage_sensor = sens; }
   void set_ram_free_sensor(sensor::Sensor *sens) { ram_free_sensor = sens; }
   void set_flash_free_sensor(sensor::Sensor *sens) { flash_free_sensor = sens; }
-  void set_presence_binary_sensor(binary_sensor::BinarySensor *presence_sensor_) {
-    presence_sensor = presence_sensor_;
-  }
+  void set_presence_binary_sensor(binary_sensor::BinarySensor *presence_sensor_) { presence_sensor = presence_sensor_; }
+  void set_entry_presence_binary_sensor(binary_sensor::BinarySensor *sensor) { entry_presence_sensor = sensor; }
+  void set_exit_presence_binary_sensor(binary_sensor::BinarySensor *sensor) { exit_presence_sensor = sensor; }
   void set_version_text_sensor(text_sensor::TextSensor *version_sensor_) { version_sensor = version_sensor_; }
   void set_entry_exit_event_text_sensor(text_sensor::TextSensor *entry_exit_event_sensor_) {
     entry_exit_event_sensor = entry_exit_event_sensor_;
@@ -160,6 +160,8 @@ class Roode : public PollingComponent {
   sensor::Sensor *ram_free_sensor{nullptr};
   sensor::Sensor *flash_free_sensor{nullptr};
   binary_sensor::BinarySensor *presence_sensor{nullptr};
+  binary_sensor::BinarySensor *entry_presence_sensor{nullptr};
+  binary_sensor::BinarySensor *exit_presence_sensor{nullptr};
   binary_sensor::BinarySensor *xshut_state_binary_sensor{nullptr};
   text_sensor::TextSensor *version_sensor{nullptr};
   text_sensor::TextSensor *entry_exit_event_sensor{nullptr};


### PR DESCRIPTION
## Summary
- support optional entry/exit presence sensors under `binary_sensor` `zones`
- expose new entry/exit presence sensors in C++ implementation
- document zone presence sensors in README

## Testing
- `python -m pytest`
- `esphome compile ci/esp32.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68ab4a07fa748330b9d50100ba60592b