### PR TITLE
Make CPU optimizations configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,10 @@ roode:
   invalid_distance_limit: 10
   # Minimum time between automatic sensor restarts
   restart_timeout: 30s
+  # Apply less aggressive filtering only when CPU usage is high
+  cpu_optimization:
+    activate: 90%
+    deactivate: 50%
   # Event logs show xshut power cycles, interrupt fallbacks and manual adjustments
 
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
@@ -329,6 +333,7 @@ reflections cause false triggers.
 | `roode.force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | `force_single_core: false` | `force_single_core: true` |
 | `roode.invalid_distance_limit` | Optional | `10` | Consecutive suspect readings before restart | Sporadic zero/4 m values | Increase if noise triggers resets | `invalid_distance_limit: 10` | `invalid_distance_limit: 20` |
 | `roode.restart_timeout` | Optional | `30s` | Cooldown and timeout before restart | Slow updates or many resets | Shorten for faster recovery | `restart_timeout: 30s` | `restart_timeout: 15s` |
+| `roode.cpu_optimization.activate` & `roode.cpu_optimization.deactivate` | Optional | `90%` / `50%` | CPU usage thresholds for enabling or disabling reduced filtering | High MCU load or disable with 100% | Raise `activate` or set to `100%` to turn off | `cpu_optimization: { activate: 90%, deactivate: 50% }` | `cpu_optimization: { activate: 95%, deactivate: 60% }` |
 | `roode.zones.invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | `zones: { invert: false }` | `zones: { invert: true }` |
 | `roode.zones.entry/exit` | Optional | none | Per-zone ROI and thresholds | Uneven hallway or obstacles | Tweak each zone separately as needed | *(not set)* | `zones:`<br>`  exit:`<br>`    roi:`<br>`      height: 8` |
 

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -37,6 +37,9 @@ CONF_LOG_FALLBACK = "log_fallback_events"
 CONF_FORCE_SINGLE_CORE = "force_single_core"
 CONF_INVALID_DISTANCE_LIMIT = "invalid_distance_limit"
 CONF_RESTART_TIMEOUT = "restart_timeout"
+CONF_CPU_OPTIMIZATION = "cpu_optimization"
+CONF_ACTIVATE = "activate"
+CONF_DEACTIVATE = "deactivate"
 
 FilterMode = roode_ns.enum("FilterMode")
 FILTER_MODES = {
@@ -95,6 +98,12 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
         cv.Optional(CONF_INVALID_DISTANCE_LIMIT, default=10): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_RESTART_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_CPU_OPTIMIZATION, default={}): cv.Schema(
+            {
+                cv.Optional(CONF_ACTIVATE, default=0.90): cv.percentage,
+                cv.Optional(CONF_DEACTIVATE, default=0.50): cv.percentage,
+            }
+        ),
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
                 cv.Optional(CONF_INVERT, default=False): cv.boolean,
@@ -122,6 +131,13 @@ async def to_code(config: Dict):
     cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
     cg.add(roode.set_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT]))
     cg.add(roode.set_restart_timeout(config[CONF_RESTART_TIMEOUT]))
+    cpu_conf = config.get(CONF_CPU_OPTIMIZATION, {})
+    cg.add(
+        roode.set_cpu_optimization_thresholds(
+            cpu_conf.get(CONF_ACTIVATE, 0.90) * 100.0,
+            cpu_conf.get(CONF_DEACTIVATE, 0.50) * 100.0,
+        )
+    )
     cg.add(roode.set_invert_direction(config[CONF_ZONES][CONF_INVERT]))
     setup_zone(CONF_ENTRY_ZONE, config, roode)
     setup_zone(CONF_EXIT_ZONE, config, roode)

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -529,21 +529,27 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
 }
 
 void Roode::apply_cpu_optimizations(float cpu) {
-  if (cpu_optimizations_active_ || cpu <= 90.0f)
+  if (cpu_optimizations_active_ || cpu <= cpu_opt_activate_threshold_)
     return;
   ESP_LOGW(TAG, "CPU usage %.1f%% exceeded threshold, applying optimizations", cpu);
   polling_interval_ms_ = 30;
-  filter_window_ = 3;
-  entry->set_filter_window(3);
-  exit->set_filter_window(3);
-  filter_mode_ = FILTER_PERCENTILE10;
-  entry->set_filter_mode(FILTER_PERCENTILE10);
-  exit->set_filter_mode(FILTER_PERCENTILE10);
+
+  // Avoid extremely small windows and accuracy-reducing filters.
+  if (filter_window_ < 5) {
+    filter_window_ = 5;
+    entry->set_filter_window(5);
+    exit->set_filter_window(5);
+  }
+  if (filter_mode_ != FILTER_MEDIAN) {
+    filter_mode_ = FILTER_MEDIAN;
+    entry->set_filter_mode(FILTER_MEDIAN);
+    exit->set_filter_mode(FILTER_MEDIAN);
+  }
   cpu_optimizations_active_ = true;
 }
 
 void Roode::reset_cpu_optimizations(float cpu) {
-  if (!cpu_optimizations_active_ || cpu > 50.0f)
+  if (!cpu_optimizations_active_ || cpu > cpu_opt_deactivate_threshold_)
     return;
   ESP_LOGI(TAG, "CPU usage %.1f%% stable, reverting optimizations", cpu);
   polling_interval_ms_ = 10;

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -129,6 +129,10 @@ class Roode : public PollingComponent {
   }
   void set_invalid_distance_limit(uint8_t limit) { invalid_distance_limit_ = limit; }
   void set_restart_timeout(uint32_t ms) { restart_timeout_ms_ = ms; }
+  void set_cpu_optimization_thresholds(float activate, float deactivate) {
+    cpu_opt_activate_threshold_ = activate;
+    cpu_opt_deactivate_threshold_ = deactivate;
+  }
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
   void set_entry_threshold_percentages(uint8_t min, uint8_t max) { entry->set_threshold_percentages(min, max); }
@@ -186,6 +190,8 @@ class Roode : public PollingComponent {
 
   bool cpu_optimizations_active_{false};
   uint16_t polling_interval_ms_{10};
+  float cpu_opt_activate_threshold_{90.0f};
+  float cpu_opt_deactivate_threshold_{50.0f};
 
   static bool log_fallback_events_;
   static Roode *instance_;


### PR DESCRIPTION
## Summary
- Keep CPU-load optimizations from aggressively shrinking the filter window or forcing percentile filtering
- Allow YAML users to tune when reduced filtering activates
- Document new CPU optimization thresholds

## Testing
- `python -m py_compile components/roode/__init__.py`
- `g++ -std=c++17 -c components/roode/roode.cpp` *(fails: Arduino.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57cfd29083308e6c99d21c2202ee