### PR TITLE
Handle repeated sensor restart failures

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -759,9 +759,20 @@ void Roode::update_status_text(const std::string &status) {
 }
 
 void Roode::restart_sensor() {
+  uint32_t now = millis();
+  if (now - last_sensor_restart_ts_ > restart_timeout_ms_)
+    restart_attempt_count_ = 0;
+  restart_attempt_count_++;
+  ESP_LOGW(TAG, "sensor_restart_attempt_%u", restart_attempt_count_);
+  log_event(std::string("sensor_restart_attempt_") + std::to_string(restart_attempt_count_));
   distanceSensor->restart();
-  last_sensor_restart_ts_ = millis();
+  last_sensor_restart_ts_ = now;
   invalid_read_count_ = 0;
+  if (restart_attempt_count_ >= max_restart_attempts_) {
+    ESP_LOGE(TAG, "sensor_restart_escalating_reset");
+    log_event("sensor_restart_escalating_reset");
+    ESP.restart();
+  }
 }
 
 void Roode::sensor_task(void *param) {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -231,6 +231,8 @@ class Roode : public PollingComponent {
   uint32_t restart_timeout_ms_{30000};
   uint8_t invalid_distance_limit_{10};
   uint8_t invalid_read_count_{0};
+  uint8_t restart_attempt_count_{0};
+  uint8_t max_restart_attempts_{3};
   static void sensor_task(void *param);
   bool use_sensor_task_{false};
   void restart_sensor();


### PR DESCRIPTION
## Summary
- log and count VL53L1X restart attempts
- escalate restart sequence by power-cycling the sensor and rebooting the ESP controller after repeated failures

## Testing
- `pio run` *(fails: esphome headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab57d22c288330a108990fdded884f