### PR TITLE
Add sensor configuration module

### DIFF
--- a/components/roode/configuration.cpp
+++ b/components/roode/configuration.cpp
@@ -1,0 +1,77 @@
+#include "configuration.h"
+
+namespace esphome {
+namespace roode {
+
+static const char *const TAG = "Configuration";
+
+Zone Configuration::getZoneConfiguration(uint8_t zone) {
+  // Create a zone object with default settings.
+  Zone cfg(zone);
+  return cfg;
+}
+
+void Configuration::setCorrectDistanceSettings(float average_entry_zone_distance,
+                                               float average_exit_zone_distance) {
+  float avg = (average_entry_zone_distance + average_exit_zone_distance) / 2.0f;
+  // Choose a ranging profile based on average distance.
+  // Values are approximations that map distance to one of the predefined modes.
+  if (avg < 1300.0f) {
+    setSensorMode(1);  // Shortest range
+  } else if (avg < 2000.0f) {
+    setSensorMode(2);  // Short
+  } else if (avg < 3000.0f) {
+    setSensorMode(3);  // Medium
+  } else if (avg < 4000.0f) {
+    setSensorMode(4);  // Long
+  } else {
+    setSensorMode(5);  // Longer distances
+  }
+}
+
+void Configuration::publishSensorConfiguration(int dist_threshold_arr[2], bool isMax) {
+  ESP_LOGD(TAG, "publishSensorConfiguration %s entry=%d exit=%d", isMax ? "max" : "min",
+           dist_threshold_arr[0], dist_threshold_arr[1]);
+}
+
+void Configuration::setSensorMode(int sensor_mode, int timing_budget) {
+  using namespace esphome::vl53l1x;
+  const RangingMode *mode = nullptr;
+  switch (sensor_mode) {
+    case 1:
+      mode = Ranging::Shortest;
+      break;
+    case 2:
+      mode = Ranging::Short;
+      break;
+    case 3:
+      mode = Ranging::Medium;
+      break;
+    case 4:
+      mode = Ranging::Long;
+      break;
+    case 5:
+      mode = Ranging::Longer;
+      break;
+    case 6:
+      mode = Ranging::Longest;
+      break;
+    default:
+      mode = Ranging::Long;
+      break;
+  }
+
+  if (timing_budget > 0 && timing_budget != mode->timing_budget) {
+    // Create a custom ranging mode with the requested timing budget.
+    mode = new RangingMode("custom", static_cast<uint16_t>(timing_budget), mode->mode);
+  }
+
+  if (sensor_ != nullptr && mode != nullptr) {
+    sensor_->set_ranging_mode(mode);
+    timing_budget_ = mode->timing_budget;
+  }
+}
+
+}  // namespace roode
+}  // namespace esphome
+

--- a/components/roode/configuration.h
+++ b/components/roode/configuration.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "zone.h"
+#include "../vl53l1x/vl53l1x.h"
+#include "esphome/core/log.h"
+
+namespace esphome {
+namespace roode {
+
+using TofSensor = esphome::vl53l1x::VL53L1X;
+
+class Configuration {
+ public:
+  explicit Configuration(TofSensor *sensor) : sensor_(sensor) {}
+
+  Zone getZoneConfiguration(uint8_t zone);
+  int getTimingBudget() const { return timing_budget_; }
+
+ private:
+  void setCorrectDistanceSettings(float average_entry_zone_distance, float average_exit_zone_distance);
+  void publishSensorConfiguration(int dist_threshold_arr[2], bool isMax);
+  void setSensorMode(int sensor_mode, int timing_budget = 0);
+
+  TofSensor *sensor_{nullptr};
+  int timing_budget_{0};
+};
+
+}  // namespace roode
+}  // namespace esphome
+


### PR DESCRIPTION
## Summary
- add preliminary configuration module for Roode sensor
- expose zone configuration and timing budget interfaces
- include helpers for sensor mode and distance-based settings

## Testing
- `pio run` *(fails: fatal error: esphome/components/number/number.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6435814083309b060c8df44e605d