### PR TITLE
feat: use configuration for zone settings

### DIFF
--- a/components/roode/configuration.cpp
+++ b/components/roode/configuration.cpp
@@ -7,7 +7,7 @@ static const char *const TAG = "Configuration";
 
 Zone Configuration::getZoneConfiguration(uint8_t zone) {
   // Create a zone object with default settings.
-  Zone cfg(zone);
+  Zone cfg(zone, this);
   return cfg;
 }
 

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -1,4 +1,5 @@
 #include "roode.h"
+#include "configuration.h"
 #include "Arduino.h"
 #ifdef CONFIG_IDF_TARGET_ESP32
 #include "esp_task_wdt.h"
@@ -115,9 +116,21 @@ void Roode::log_event(const std::string &msg) {
   }
 }
 
+void Roode::set_tof_sensor(TofSensor *sensor) {
+  this->distanceSensor = sensor;
+  if (configuration_ == nullptr)
+    configuration_ = new Configuration(sensor);
+  if (entry == nullptr)
+    entry = new Zone(0, configuration_);
+  if (exit == nullptr)
+    exit = new Zone(1, configuration_);
+  current_zone = entry;
+}
+
 Roode::~Roode() {
   delete entry;
   delete exit;
+  delete configuration_;
 }
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -19,6 +19,7 @@ using TofSensor = esphome::vl53l1x::VL53L1X;
 
 namespace esphome {
 namespace roode {
+class Configuration;
 #define NOBODY 0
 #define SOMEONE 1
 #define VERSION "1.7.0"
@@ -67,7 +68,7 @@ class Roode : public PollingComponent {
   float get_setup_priority() const override { return setup_priority::PROCESSOR; };
 
   TofSensor *get_tof_sensor() { return this->distanceSensor; }
-  void set_tof_sensor(TofSensor *sensor) { this->distanceSensor = sensor; }
+  void set_tof_sensor(TofSensor *sensor);
   void set_invert_direction(bool dir) { invert_direction_ = dir; }
   void set_orientation(Orientation val) { orientation_ = val; }
   void set_sampling_size(uint8_t size) {
@@ -136,12 +137,13 @@ class Roode : public PollingComponent {
   void apply_cpu_optimizations(float cpu);
   void reset_cpu_optimizations(float cpu);
   void update_metrics();
-  Zone *entry = new Zone(0);
-  Zone *exit = new Zone(1);
+  Zone *entry{nullptr};
+  Zone *exit{nullptr};
   static void log_event(const std::string &msg);
 
  protected:
   TofSensor *distanceSensor;
+  Configuration *configuration_{nullptr};
   Zone *current_zone = entry;
   sensor::Sensor *distance_entry{nullptr};
   sensor::Sensor *distance_exit{nullptr};

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -1,5 +1,7 @@
 #include "zone.h"
+#include "configuration.h"
 #include <algorithm>
+#include <Arduino.h>
 
 namespace esphome {
 namespace roode {
@@ -77,6 +79,7 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
   std::vector<int> zone_distances;
   zone_distances.reserve(number_attempts);
   int sum = 0;
+  int delay_ms = configuration != nullptr ? configuration->getTimingBudget() : 0;
   for (int i = 0; i < number_attempts; i++) {
     this->readDistance(distanceSensor);
     if (sensor_status != VL53L1_ERROR_NONE) {
@@ -85,6 +88,8 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
     }
     zone_distances.push_back(this->getDistance());
     sum += zone_distances.back();
+    if (delay_ms > 0)
+      delay(delay_ms);
   };
   if (zone_distances.empty()) {
     threshold->idle = 0;
@@ -107,6 +112,15 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
 }
 
 void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation) {
+  if (configuration != nullptr) {
+    Zone cfg = configuration->getZoneConfiguration(id);
+    if (cfg.roi->width)
+      this->roi_override->width = cfg.roi->width;
+    if (cfg.roi->height)
+      this->roi_override->height = cfg.roi->height;
+    if (cfg.roi->center)
+      this->roi_override->center = cfg.roi->center;
+  }
   // the value of the average distance is used for computing the optimal size of the ROI and consequently also the
   // center of the two zones
   int function_of_the_distance = 16 * (1 - (0.15 * 2) / (0.34 * (min(entry_threshold, exit_threshold) / 1000)));

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -16,6 +16,7 @@ static const char *const TAG = "Zone";
 static const char *const CALIBRATION = "Zone calibration";
 namespace esphome {
 namespace roode {
+class Configuration;
 enum FilterMode { FILTER_MIN, FILTER_MEDIAN, FILTER_PERCENTILE10 };
 struct Threshold {
   /** Automatically determined idling distance (average of several measurements) */
@@ -32,7 +33,7 @@ struct Threshold {
 
 class Zone {
  public:
-  explicit Zone(uint8_t id) : id{id} {};
+  explicit Zone(uint8_t id, Configuration *config) : id{id}, configuration(config) {};
   ~Zone();
   void dump_config() const;
   VL53L1_Error readDistance(TofSensor *distanceSensor);
@@ -46,6 +47,7 @@ class Zone {
   ROI *roi = new ROI();
   ROI *roi_override = new ROI();
   Threshold *threshold = new Threshold();
+  Configuration *configuration;
   void set_filter_mode(FilterMode mode) { filter_mode_ = mode; }
   void set_filter_window(uint8_t window) {
     max_samples = std::min<uint8_t>(window, MAX_BUFFER_SIZE);


### PR DESCRIPTION
## Summary
- pass `Configuration` into `Zone` and use it for timing and ROI data
- build zones through `set_tof_sensor` and manage `Configuration` lifecycle

## Testing
- `pio run` *(fails: esphome/core headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab660a1e4c8330b8218ed51119b5fe