### PR TITLE
Add calibration session schema and document naming conventions

### DIFF
--- a/components/roode/schema.py
+++ b/components/roode/schema.py
@@ -1,0 +1,69 @@
+"""Schema definitions for Roode Home Assistant integration.
+
+This module centralizes the data format used by calibration and analysis
+components. A session record describes a single ranging measurement and
+is shared between ESPHome firmware and Home Assistant post-processing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, List, TypedDict
+
+
+class SessionRecordDict(TypedDict):
+    """Dictionary representation of a session record."""
+
+    type: str
+    grid: str
+    trial: int
+    ranging: int
+    timestamp: str
+    data: List[Any]
+
+
+@dataclass
+class SessionRecord:
+    """Represents one entry in a calibration or ranging session.
+
+    Attributes:
+        type: Identifier for the record type.
+        grid: ROI grid or positional reference.
+        trial: Sequential trial number within the session.
+        ranging: Raw ranging result from the sensor in millimetres.
+        timestamp: Creation time in ISO 8601 format.
+        data: Arbitrary metadata captured with the measurement.
+    """
+
+    type: str
+    grid: str
+    trial: int
+    ranging: int
+    timestamp: datetime
+    data: List[Any] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, payload: SessionRecordDict) -> "SessionRecord":
+        """Create a :class:`SessionRecord` from its dictionary form."""
+
+        return cls(
+            type=payload["type"],
+            grid=payload["grid"],
+            trial=payload["trial"],
+            ranging=payload["ranging"],
+            timestamp=datetime.fromisoformat(payload["timestamp"]),
+            data=list(payload.get("data", [])),
+        )
+
+    def to_dict(self) -> SessionRecordDict:
+        """Convert the record to a serialisable dictionary."""
+
+        return {
+            "type": self.type,
+            "grid": self.grid,
+            "trial": self.trial,
+            "ranging": self.ranging,
+            "timestamp": self.timestamp.isoformat(),
+            "data": self.data,
+        }

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -23,3 +23,32 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
     data:
       newCount: "{{ states('input_number.set_people32') | int }}"
 ```
+
+## Calibration Session Data
+
+Calibration measurements are written to timestamped folders using the
+pattern `calibration_YYYY-MM-DD_HH-MM/`.  Each session directory
+initially contains a `session.json` file holding the raw records defined
+in `components/roode/schema.py`.  After post-analysis, an additional
+`roi_result.json` file may be stored in the same directory.
+
+Example layout:
+
+```
+calibration_2024-04-23_14-30/
+├── session.json
+└── roi_result.json
+```
+
+Within `session.json` every entry uses the following fields:
+
+- `type` – record type identifier
+- `grid` – ROI grid or positional reference
+- `trial` – sequential trial number
+- `ranging` – raw ranging value in millimetres
+- `timestamp` – ISO 8601 timestamp when recorded
+- `data` – arbitrary metadata
+
+Timestamps use a `YYYY-MM-DD_HH-MM` prefix for the directory and ISO 8601
+format within the JSON entries.  Using this naming convention allows
+other components to discover and share session data reliably.


### PR DESCRIPTION
## Summary
- add `SessionRecord` schema module describing calibration data fields
- document timestamped `calibration_YYYY-MM-DD_HH-MM/` session folder with `session.json` and `roi_result.json`

## Testing
- `python -m py_compile components/roode/schema.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab6ce2a950833085097d237d904b3e