### PR TITLE
Add WebSocket session recorder

### DIFF
--- a/home_assistant.md
+++ b/home_assistant.md
@@ -52,3 +52,17 @@ Within `session.json` every entry uses the following fields:
 Timestamps use a `YYYY-MM-DD_HH-MM` prefix for the directory and ISO 8601
 format within the JSON entries.  Using this naming convention allows
 other components to discover and share session data reliably.
+
+### Collecting Calibration Sessions
+
+A helper script `session_recorder.py` listens for the device's WebSocket
+messages and stores them in `session.json`:
+
+```bash
+python session_recorder.py ws://device.local/session
+```
+
+Each JSON payload from the device is appended as a line to the session file.
+When a message with `type` set to `scan_complete` is received, the script
+closes the file and optionally runs a follow-up analysis command supplied via
+`--analysis`.

--- a/session_recorder.py
+++ b/session_recorder.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Record calibration sessions from a Roode device.
+
+This utility subscribes to a device's JSON message stream and appends each
+payload to a ``session.json`` file.  When a message with ``type`` equal to
+``scan_complete`` is received the session is closed and an optional analysis
+command is executed.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import websockets
+
+
+async def record_session(url: str, session_dir: Path, analysis_cmd: Optional[Iterable[str]]) -> None:
+    """Subscribe to ``url`` and write JSON messages to ``session_dir``.
+
+    Args:
+        url: WebSocket URL of the device.
+        session_dir: Directory where ``session.json`` is stored.
+        analysis_cmd: Command to run after ``scan_complete``.
+    """
+    session_dir.mkdir(parents=True, exist_ok=True)
+    session_file = session_dir / "session.json"
+
+    async with websockets.connect(url) as ws, session_file.open("a", encoding="utf-8") as fh:
+        async for message in ws:
+            fh.write(message.strip() + "\n")
+            try:
+                payload = json.loads(message)
+            except json.JSONDecodeError:
+                continue
+            if payload.get("type") == "scan_complete":
+                break
+
+    if analysis_cmd:
+        subprocess.run(list(analysis_cmd) + [str(session_dir)], check=False)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url", help="WebSocket URL of the device")
+    parser.add_argument(
+        "session_dir",
+        nargs="?",
+        default=None,
+        help="Directory to store session data (default: calibration_<timestamp>)",
+    )
+    parser.add_argument(
+        "--analysis",
+        nargs=argparse.REMAINDER,
+        help="Command to run after scan_complete (session path appended)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    session_dir = (
+        Path(args.session_dir)
+        if args.session_dir
+        else Path(datetime.now().strftime("calibration_%Y-%m-%d_%H-%M"))
+    )
+    asyncio.run(record_session(args.url, session_dir, args.analysis))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document how calibration sessions are stored and add usage guide
- add Python utility to record device messages into `session.json`

## Testing
- `python -m py_compile session_recorder.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab6db90bf4833081621db4e810cce8