### PR TITLE
Add passive scan trigger and ESPHome service

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -185,8 +185,7 @@ void Roode::setup() {
   } else {
     calibrate_zones();
   }
-  last_calibration_ts_ =
-      std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
+  last_calibration_ts_ = std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
 #ifdef CONFIG_IDF_TARGET_ESP32
   if (!force_single_core_) {
     log_event("use_dual_core");
@@ -300,8 +299,7 @@ void Roode::loop() {
   } else {
     invalid_read_count_ = 0;
   }
-  if (invalid_read_count_ > invalid_distance_limit_ &&
-      (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
+  if (invalid_read_count_ > invalid_distance_limit_ && (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
     ESP_LOGW(TAG, "Consecutive invalid distances, restarting...");
     restart_sensor();
   }
@@ -320,8 +318,7 @@ void Roode::loop() {
   loop_count_++;
   update_metrics();
   uint32_t now_epoch = static_cast<uint32_t>(time(nullptr));
-  if (auto_calibration_interval_sec_ > 0 &&
-      now_epoch - last_calibration_ts_ >= auto_calibration_interval_sec_) {
+  if (auto_calibration_interval_sec_ > 0 && now_epoch - last_calibration_ts_ >= auto_calibration_interval_sec_) {
     run_zone_calibration(0);
     run_zone_calibration(1);
   }
@@ -511,6 +508,8 @@ void Roode::updateCounter(int delta) {
 }
 void Roode::recalibration() { calibrate_zones(); }
 
+void Roode::start_passive_scan() { ESP_LOGI(TAG, "Passive scan start command received"); }
+
 void Roode::run_zone_calibration(uint8_t zone_id) {
   ESP_LOGI(CALIBRATION, "Calibration triggered for zone %d", zone_id);
   Zone *z = zone_id == 0 ? entry : exit;
@@ -534,8 +533,7 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   // thresholds and ROI values immediately after a fail-safe recalibration
   publish_sensor_configuration(entry, exit, true);
   publish_sensor_configuration(entry, exit, false);
-  last_calibration_ts_ =
-      std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
+  last_calibration_ts_ = std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
   publish_feature_list();
 }
 
@@ -659,8 +657,7 @@ void Roode::calibrate_zones() {
     calibration_prefs_[1].save(&calibration_data_[1]);
   }
   ESP_LOGI(SETUP, "Finished calibrating sensor zones");
-  last_calibration_ts_ =
-      std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
+  last_calibration_ts_ = std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
   publish_feature_list();
 }
 
@@ -769,7 +766,6 @@ void Roode::publish_feature_list() {
   log_event(std::string("features_enabled: ") + feature_list);
 }
 
-
 void Roode::update_status_text(const std::string &status) {
   if (status_text_sensor != nullptr && status != last_status_text_) {
     status_text_sensor->publish_state(status);
@@ -799,8 +795,7 @@ void Roode::sensor_task(void *param) {
   for (;;) {
     self->use_sensor_task_ = true;
     uint32_t now = millis();
-    if (self->last_loop_update_ts_ != 0 &&
-        (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
+    if (self->last_loop_update_ts_ != 0 && (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
         (now - self->last_sensor_restart_ts_ > self->restart_timeout_ms_)) {
       ESP_LOGW(TAG, "Sensor unresponsive >%ds, restarting...", self->restart_timeout_ms_ / 1000);
       self->restart_sensor();

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -135,6 +135,7 @@ class Roode : public PollingComponent {
   }
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
+  void start_passive_scan();
   void set_entry_threshold_percentages(uint8_t min, uint8_t max) { entry->set_threshold_percentages(min, max); }
   void set_exit_threshold_percentages(uint8_t min, uint8_t max) { exit->set_threshold_percentages(min, max); }
   void apply_cpu_optimizations(float cpu);

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -24,6 +24,42 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
       newCount: "{{ states('input_number.set_people32') | int }}"
 ```
 
+## Passive Scan Trigger
+
+Add an `input_select` to request a passive scan session and an
+automation that calls a helper script:
+
+```
+input_select:
+  roode_action:
+    name: Roode Action
+    options:
+      - idle
+      - start_passive_scan
+
+automation:
+  - alias: "Start Roode passive scan"
+    trigger:
+      platform: state
+      entity_id: input_select.roode_action
+      to: "start_passive_scan"
+    action:
+      - service: python_script.start_passive_scan
+        data:
+          device: roode32
+      - service: input_select.select_option
+        target:
+          entity_id: input_select.roode_action
+        data:
+          option: idle
+```
+
+Place `homeassistant/python_scripts/start_passive_scan.py` into your
+Home Assistant configuration. Selecting `start_passive_scan` creates a
+timestamped `passive_scan_YYYY-MM-DD_HH-MM/` directory with an empty
+`session.json` and dispatches an `esphome.<node>_start_passive_scan`
+command to the ESPHome node.
+
 ## Calibration Session Data
 
 Calibration measurements are written to timestamped folders using the

--- a/homeassistant/python_scripts/start_passive_scan.py
+++ b/homeassistant/python_scripts/start_passive_scan.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+import json
+from pathlib import Path
+
+# Determine the device name from data or fall back to roode32
+node = data.get("device", "roode32")
+
+# Create session directory using timestamp
+session_name = datetime.now().strftime("passive_scan_%Y-%m-%d_%H-%M")
+session_dir = Path(hass.config.path(session_name))
+session_dir.mkdir(parents=True, exist_ok=True)
+
+# Initialize session.json as an empty list
+(session_dir / "session.json").write_text(json.dumps([]))
+
+# Dispatch start command to ESPHome node
+service = f"{node}_start_passive_scan"
+hass.services.call("esphome", service, {})

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -28,13 +28,16 @@ wifi:
 
 captive_portal:
 
-api:
-  password: !secret api_password
-  reboot_timeout: 60min
-  services:
-    - service: recalibrate
-      then:
-        - lambda: "id(roode_platform)->recalibration();"
+  api:
+    password: !secret api_password
+    reboot_timeout: 60min
+    services:
+      - service: recalibrate
+        then:
+          - lambda: "id(roode_platform)->recalibration();"
+      - service: start_passive_scan
+        then:
+          - lambda: "id(roode_platform)->start_passive_scan();"
 
 ota:
   password: !secret ota_password

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -32,6 +32,9 @@ api:
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
+    - service: start_passive_scan
+      then:
+        - lambda: "id(roode_platform)->start_passive_scan();"
 
 ota:
   password: !secret ota_password

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -32,6 +32,9 @@ api:
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
+    - service: start_passive_scan
+      then:
+        - lambda: "id(roode_platform)->start_passive_scan();"
 
 ota:
   password: !secret ota_password

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -29,6 +29,9 @@ api:
     - service: recalibrate
       then:
         - lambda: "id(roode_platform)->recalibration();"
+    - service: start_passive_scan
+      then:
+        - lambda: "id(roode_platform)->start_passive_scan();"
 
 ota:
   password: !secret ota_password


### PR DESCRIPTION
## Summary
- add Home Assistant input_select automation for `start_passive_scan`
- create `python_scripts/start_passive_scan.py` helper to spawn session folder and dispatch ESPHome command
- expose `start_passive_scan` service in ESPHome and stub handler in Roode component

## Testing
- `python -m py_compile homeassistant/python_scripts/start_passive_scan.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6db551ac83308dd9a785c846501d