### PR TITLE
Expose calibration monitoring metrics

### DIFF
--- a/Documents/developer_notes.md
+++ b/Documents/developer_notes.md
@@ -1,0 +1,12 @@
+# Developer Notes
+
+## Calibration Sensors
+
+### variance_cv_mask
+Reports the coefficient of variation for the MCPS mask collected during a passive scan. Higher values indicate inconsistent readings across the region-of-interest grid.
+
+### trial_bump_cv
+Represents the coefficient of variation for distance measurements observed in each trial of a passive scan. It helps evaluate the stability of bump detection across trials.
+
+### scan_time_cap_seconds
+Publishes the total elapsed time of the passive scan session in seconds, allowing monitoring of the scan duration.

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <vector>
 #include <algorithm>
+#include <cmath>
 #include <ctime>
 #include <sstream>
 
@@ -791,6 +792,34 @@ void Roode::start_passive_scan() {
       for (const char *mode : modes) {
         std::vector<int> mcps(grid * grid, 0);
         std::vector<int> distance(grid * grid, 0);
+        float mean_mcps = 0.0f;
+        for (int v : mcps)
+          mean_mcps += v;
+        mean_mcps /= mcps.size();
+        float var_mcps = 0.0f;
+        for (int v : mcps) {
+          float diff = v - mean_mcps;
+          var_mcps += diff * diff;
+        }
+        var_mcps /= mcps.size();
+        float cv_mask = mean_mcps != 0.0f ? (sqrtf(var_mcps) / mean_mcps) * 100.0f : 0.0f;
+        if (variance_cv_mask_sensor != nullptr)
+          variance_cv_mask_sensor->publish_state(cv_mask);
+
+        float mean_dist = 0.0f;
+        for (int v : distance)
+          mean_dist += v;
+        mean_dist /= distance.size();
+        float var_dist = 0.0f;
+        for (int v : distance) {
+          float diff = v - mean_dist;
+          var_dist += diff * diff;
+        }
+        var_dist /= distance.size();
+        float cv_trial = mean_dist != 0.0f ? (sqrtf(var_dist) / mean_dist) * 100.0f : 0.0f;
+        if (trial_bump_cv_sensor != nullptr)
+          trial_bump_cv_sensor->publish_state(cv_trial);
+
         std::stringstream mcps_ss;
         mcps_ss << '[';
         for (size_t i = 0; i < mcps.size(); ++i) {
@@ -823,6 +852,9 @@ void Roode::start_passive_scan() {
     }
   }
   publish_scan_record("scan_complete");
+  float elapsed = (millis() - scan_start_ts_) / 1000.0f;
+  if (scan_time_cap_seconds_sensor != nullptr)
+    scan_time_cap_seconds_sensor->publish_state(elapsed);
 }
 
 void Roode::restart_sensor() {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -113,6 +113,9 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }
   void set_sensor_status_text_sensor(text_sensor::TextSensor *sensor_) { status_text_sensor = sensor_; }
   void set_manual_adjustment_sensor(sensor::Sensor *sens) { manual_adjustment_sensor = sens; }
+  void set_variance_cv_mask_sensor(sensor::Sensor *sens) { variance_cv_mask_sensor = sens; }
+  void set_trial_bump_cv_sensor(sensor::Sensor *sens) { trial_bump_cv_sensor = sens; }
+  void set_scan_time_cap_seconds_sensor(sensor::Sensor *sens) { scan_time_cap_seconds_sensor = sens; }
   void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
   void set_force_single_core(bool val) { force_single_core_ = val; }
   void set_calibration_persistence(bool val) { calibration_persistence_ = val; }
@@ -174,6 +177,9 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   text_sensor::TextSensor *status_text_sensor{nullptr};
   sensor::Sensor *manual_adjustment_sensor{nullptr};
   sensor::Sensor *interrupt_status_sensor{nullptr};
+  sensor::Sensor *variance_cv_mask_sensor{nullptr};
+  sensor::Sensor *trial_bump_cv_sensor{nullptr};
+  sensor::Sensor *scan_time_cap_seconds_sensor{nullptr};
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -30,6 +30,9 @@ CONF_RAM_FREE = "ram_free"
 CONF_FLASH_FREE = "flash_free"
 CONF_MANUAL_ADJUST = "manual_adjustment_count"
 CONF_INTERRUPT_STATUS = "interrupt_status"
+CONF_VARIANCE_CV_MASK = "variance_cv_mask"
+CONF_TRIAL_BUMP_CV = "trial_bump_cv"
+CONF_SCAN_TIME_CAP_SECONDS = "scan_time_cap_seconds"
 
 CONFIG_SCHEMA = sensor.sensor_schema().extend(
     {
@@ -146,6 +149,27 @@ CONFIG_SCHEMA = sensor.sensor_schema().extend(
             accuracy_decimals=0,
             entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
         ),
+        cv.Optional(CONF_VARIANCE_CV_MASK): sensor.sensor_schema(
+            icon="mdi:chart-box",
+            unit_of_measurement="%",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_TRIAL_BUMP_CV): sensor.sensor_schema(
+            icon="mdi:chart-line",
+            unit_of_measurement="%",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
+        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS): sensor.sensor_schema(
+            icon="mdi:timer",
+            unit_of_measurement="s",
+            accuracy_decimals=1,
+            state_class=STATE_CLASS_MEASUREMENT,
+            entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+        ),
         cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
     }
 )
@@ -204,3 +228,12 @@ async def to_code(config):
     if CONF_MANUAL_ADJUST in config:
         count = await sensor.new_sensor(config[CONF_MANUAL_ADJUST])
         cg.add(var.set_manual_adjustment_sensor(count))
+    if CONF_VARIANCE_CV_MASK in config:
+        sens = await sensor.new_sensor(config[CONF_VARIANCE_CV_MASK])
+        cg.add(var.set_variance_cv_mask_sensor(sens))
+    if CONF_TRIAL_BUMP_CV in config:
+        sens = await sensor.new_sensor(config[CONF_TRIAL_BUMP_CV])
+        cg.add(var.set_trial_bump_cv_sensor(sens))
+    if CONF_SCAN_TIME_CAP_SECONDS in config:
+        sens = await sensor.new_sensor(config[CONF_SCAN_TIME_CAP_SECONDS])
+        cg.add(var.set_scan_time_cap_seconds_sensor(sens))


### PR DESCRIPTION
## Summary
- Add optional sensors for variance_cv_mask, trial_bump_cv and scan_time_cap_seconds
- Publish calibration variance, trial CV and scan duration values during passive scans
- Describe new calibration sensors in developer notes

## Testing
- `clang-format -i components/roode/roode.h components/roode/roode.cpp`
- `python -m py_compile components/roode/sensor.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab6f5542b0833098ae81ff50b65fbf