### PR TITLE
Add ROI configuration example and OTA update snippet

### DIFF
--- a/ota_roi_update.yaml
+++ b/ota_roi_update.yaml
@@ -1,0 +1,26 @@
+---
+esphome:
+  name: roode32
+
+esp32:
+  board: wemos_d1_mini32
+
+wifi:
+  ssid: !secret ssid1
+  password: !secret ssid1_password
+
+api:
+
+ota:
+
+external_components:
+  - source: github://Lyr3x/Roode
+
+vl53l1x:
+  sensor_id: 1
+  calibration:
+    ranging: short
+
+roode:
+  id: roode_platform
+  roi_result: roi_result.json

--- a/roi_result.json
+++ b/roi_result.json
@@ -1,0 +1,18 @@
+{
+  "grid": 8,
+  "mode": "short",
+  "roi": {
+    "width": 6,
+    "height": 16,
+    "center": 195
+  },
+  "zones": {
+    "entry": {"center": 167},
+    "exit": {"center": 231}
+  },
+  "thresholds": {
+    "min": 0.10,
+    "max": 0.85
+  },
+  "recommended_trials": 25
+}


### PR DESCRIPTION
## Summary
- add sample `roi_result.json` with ROI size, zone centers, thresholds, and ranging mode
- provide `ota_roi_update.yaml` to apply ROI result via OTA

## Testing
- `python -m json.tool roi_result.json`
- `yamllint ota_roi_update.yaml`


------
https://chatgpt.com/codex/tasks/task_e_68ab7338cd888330a158ab747f05c80d