### PR TITLE
feat: add calibration dashboard

### DIFF
--- a/home_assistant.md
+++ b/home_assistant.md
@@ -60,6 +60,29 @@ timestamped `passive_scan_YYYY-MM-DD_HH-MM/` directory with an empty
 `session.json` and dispatches an `esphome.<node>_start_passive_scan`
 command to the ESPHome node.
 
+## Calibration Dashboard
+
+Import the Lovelace view in `homeassistant/roode_dashboard.yaml` to add a
+dedicated panel for running scans and reviewing results. The view provides
+buttons to start a passive scan, accept the computed ROI or rerun the
+calibration.
+
+To expose advanced tuning options, add an `input_boolean` that acts as a
+"Show expert parameters" toggle:
+
+```
+input_boolean:
+  roode_show_expert:
+    name: Show expert parameters
+```
+
+Place `homeassistant/python_scripts/apply_roi_result.py` alongside the scan
+script. When the *Accept* button is pressed, the script copies the most
+recent `roi_result.json` into the Home Assistant configuration directory so
+it can be used for an OTA update. After a scan finishes, the panel displays
+ROI dimensions and detection thresholds; enabling *Show expert parameters*
+reveals additional tunable defaults.
+
 ## Calibration Session Data
 
 Calibration measurements are written to timestamped folders using the

--- a/homeassistant/python_scripts/apply_roi_result.py
+++ b/homeassistant/python_scripts/apply_roi_result.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import shutil
+
+# Use device name if provided, default to roode32
+node = data.get("device", "roode32")
+config_dir = Path(hass.config.path())
+
+# Find newest calibration directory
+sessions = sorted(config_dir.glob("calibration_*"))
+if not sessions:
+    logger.warning("No calibration sessions found")
+else:
+    latest = sessions[-1]
+    src = latest / "roi_result.json"
+    if not src.exists():
+        logger.warning("No roi_result.json in %s", latest)
+    else:
+        dst = config_dir / "roi_result.json"
+        shutil.copy(src, dst)
+        logger.info("Copied %s to %s for %s", src, dst, node)

--- a/homeassistant/roode_dashboard.yaml
+++ b/homeassistant/roode_dashboard.yaml
@@ -1,0 +1,73 @@
+title: Roode Calibration
+path: roode-calibration
+cards:
+  - type: vertical-stack
+    cards:
+      - type: button
+        name: Start Scan
+        icon: mdi:play
+        tap_action:
+          action: call-service
+          service: python_script.start_passive_scan
+          service_data:
+            device: roode32
+      - type: entity
+        entity: sensor.roode32_scan_time_cap_seconds
+        name: Scan duration
+      - type: entities
+        title: ROI & Thresholds
+        entities:
+          - entity: sensor.roode32_roi_height_zone_0
+            name: ROI height entry
+          - entity: sensor.roode32_roi_width_zone_0
+            name: ROI width entry
+          - entity: sensor.roode32_roi_height_zone_1
+            name: ROI height exit
+          - entity: sensor.roode32_roi_width_zone_1
+            name: ROI width exit
+          - entity: sensor.roode32_min_threshold_entry
+            name: Min threshold entry
+          - entity: sensor.roode32_max_threshold_entry
+            name: Max threshold entry
+          - entity: sensor.roode32_min_threshold_exit
+            name: Min threshold exit
+          - entity: sensor.roode32_max_threshold_exit
+            name: Max threshold exit
+      - type: horizontal-stack
+        cards:
+          - type: button
+            name: Accept
+            icon: mdi:check
+            tap_action:
+              action: call-service
+              service: python_script.apply_roi_result
+              service_data:
+                device: roode32
+          - type: button
+            name: Rerun
+            icon: mdi:refresh
+            tap_action:
+              action: call-service
+              service: python_script.start_passive_scan
+              service_data:
+                device: roode32
+      - type: entities
+        entities:
+          - entity: input_boolean.roode_show_expert
+            name: Show expert parameters
+      - type: conditional
+        conditions:
+          - entity: input_boolean.roode_show_expert
+            state: "on"
+        card:
+          type: entities
+          title: Expert Parameters
+          entities:
+            - entity: number.roode_entry_threshold_min
+              name: Entry min threshold
+            - entity: number.roode_entry_threshold_max
+              name: Entry max threshold
+            - entity: number.roode_exit_threshold_min
+              name: Exit min threshold
+            - entity: number.roode_exit_threshold_max
+              name: Exit max threshold


### PR DESCRIPTION
## Summary
- add Home Assistant panel to start scans and review ROI/thresholds
- copy latest ROI result into config via new acceptance script
- document dashboard usage and expert parameter toggle

## Testing
- `python -m py_compile homeassistant/python_scripts/apply_roi_result.py homeassistant/python_scripts/start_passive_scan.py`
- `python - <<'PY'
import yaml, pathlib
for f in pathlib.Path('homeassistant').glob('*.yaml'):
    with open(f) as fh:
        yaml.safe_load(fh)
    print('OK', f)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ab74a1ce90833088a7c11702a97080