### PR TITLE
Fix ROI result file validation for ESPHome 2025.7.5

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -107,7 +107,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DEACTIVATE, default=0.50): cv.percentage,
             }
         ),
-        cv.Optional(CONF_ROI_RESULT): cv.file,
+        cv.Optional(CONF_ROI_RESULT): cv.file_,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
                 cv.Optional(CONF_INVERT, default=False): cv.boolean,


### PR DESCRIPTION
## Summary
- fix ROI result file option to use `cv.file_`

## Testing
- `python -m py_compile components/roode/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab78c51c88833099a19924f2b1c1f1