### PR TITLE
Fix duplicate passive scan method declarations

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -128,7 +128,7 @@ void Roode::dump_config() {
 
 void Roode::setup() {
   ESP_LOGI(SETUP, "Booting Roode %s", VERSION);
-  this->register_service(&Roode::start_passive_scan, "start_passive_scan");
+  register_service(&Roode::start_passive_scan, "start_passive_scan");
   if (version_sensor != nullptr) {
     version_sensor->publish_state(VERSION);
   }
@@ -502,9 +502,6 @@ void Roode::updateCounter(int delta) {
   call.perform();
 }
 void Roode::recalibration() { calibrate_zones(); }
-
-void Roode::start_passive_scan() { ESP_LOGI(TAG, "Passive scan start command received"); }
-
 void Roode::run_zone_calibration(uint8_t zone_id) {
   ESP_LOGI(CALIBRATION, "Calibration triggered for zone %d", zone_id);
   Zone *z = zone_id == 0 ? entry : exit;

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -139,7 +139,6 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   }
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();
-  void start_passive_scan();
   void set_entry_threshold_percentages(uint8_t min, uint8_t max) { entry->set_threshold_percentages(min, max); }
   void set_exit_threshold_percentages(uint8_t min, uint8_t max) { exit->set_threshold_percentages(min, max); }
   void apply_cpu_optimizations(float cpu);


### PR DESCRIPTION
## Summary
- remove duplicate `start_passive_scan` declarations and implementation
- register passive scan service during setup

## Testing
- `pio run -e roode` *(fails: esphome headers missing)*
- `esphome compile peopleCounter32Dev.yaml` *(fails: `ota` requires `platform` key)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7a5547708330a2958fdaf00694f5