### PR TITLE
Fix service registration in Roode component

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -128,7 +128,7 @@ void Roode::dump_config() {
 
 void Roode::setup() {
   ESP_LOGI(SETUP, "Booting Roode %s", VERSION);
-  register_service(&Roode::start_passive_scan, "start_passive_scan");
+  this->register_service(&Roode::start_passive_scan, "start_passive_scan");
   if (version_sensor != nullptr) {
     version_sensor->publish_state(VERSION);
   }


### PR DESCRIPTION
## Summary
- Qualify `register_service` with `this->` in Roode setup

## Testing
- `esphome compile ci/test_api.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68ab7b9c564c833082e797874163cd5d