### PR TITLE
Add auto calibration block for Roode

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,9 +217,8 @@ roode:
     # an example of absolute units
     # min: 50mm
     # max: 234cm
-
-  # Persist calibration data so thresholds survive restarts
-  calibration_persistence: true
+  # Automatic calibration settings (seconds)
+  auto_calibration: { interval: 14400, persist: true }
 
   # Jitter reduction options
   filter_mode: median  # min, median or percentile10
@@ -374,7 +373,7 @@ Tweak one parameter at a time and verify performance before making further adjus
 | `roode.orientation` | Optional | `parallel` | Sensor pad orientation | Sensor rotated 90° | Set to `perpendicular` | `orientation: parallel` | `orientation: perpendicular` |
 | `roode.roi` | Optional | `h16 w6` | Size of measurement window | Narrow doorway or wide hall | Change by 2–4 units or use `auto` to learn | `roi: { height: 16, width: 6 }` | `roi: auto` |
 | `roode.detection_thresholds` | Optional | `min:0% max:85%` | Distance limits for detecting people | Sensor too close or far from traffic | Raise `min` ~5% (or ~50 mm) each time | `detection_thresholds: { min: 5%, max: 85% }` | `detection_thresholds: { min: 50mm, max: 234cm }` |
-| `roode.calibration_persistence` | Optional | `false` | Save thresholds in flash | Sensor reboots often | Enable to keep tuning | `calibration_persistence: false` | `calibration_persistence: true` |
+| `roode.auto_calibration.interval` & `roode.auto_calibration.persist` | Optional | `interval: 14400, persist: false` | Auto recalibration schedule and persistence | Sensor reboots often or needs periodic tuning | Adjust interval or enable persistence | `auto_calibration: { interval: 14400, persist: false }` | `auto_calibration: { interval: 3600, persist: true }` |
 | `roode.filter_mode` & `roode.filter_window` | Optional | `min` / `5` | How samples are combined and window size | Noisy environment | Use `median`/`percentile10` with larger windows | `filter_mode: min`<br>`filter_window: 5` | `filter_mode: percentile10`<br>`filter_window: 9` |
 | `roode.log_fallback_events` | Optional | `false` | Record INT/XSHUT fallback events | Debugging unexpected counts | Enable while testing | `log_fallback_events: false` | `log_fallback_events: true` |
 | `roode.force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | `force_single_core: false` | `force_single_core: true` |

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -32,7 +32,9 @@ CONF_MIN = "min"
 CONF_ROI = "roi"
 CONF_SAMPLING = "sampling"
 CONF_ZONES = "zones"
-CONF_CALIBRATION_PERSISTENCE = "calibration_persistence"
+CONF_AUTO_CALIBRATION = "auto_calibration"
+CONF_INTERVAL = "interval"
+CONF_PERSIST = "persist"
 CONF_FILTER_MODE = "filter_mode"
 CONF_FILTER_WINDOW = "filter_window"
 CONF_LOG_FALLBACK = "log_fallback_events"
@@ -94,7 +96,12 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_SAMPLING, default=2): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_ROI, default={}): ROI_SCHEMA,
         cv.Optional(CONF_DETECTION_THRESHOLDS, default={}): THRESHOLDS_SCHEMA,
-        cv.Optional(CONF_CALIBRATION_PERSISTENCE, default=False): cv.boolean,
+        cv.Optional(CONF_AUTO_CALIBRATION, default={}): cv.Schema(
+            {
+                cv.Optional(CONF_INTERVAL, default=4 * 60 * 60): cv.uint32_t,
+                cv.Optional(CONF_PERSIST, default=False): cv.boolean,
+            }
+        ),
         cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
         cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_LOG_FALLBACK, default=False): cv.boolean,
@@ -128,7 +135,9 @@ async def to_code(config: Dict):
 
     cg.add(roode.set_orientation(config[CONF_ORIENTATION]))
     cg.add(roode.set_sampling_size(config[CONF_SAMPLING]))
-    cg.add(roode.set_calibration_persistence(config[CONF_CALIBRATION_PERSISTENCE]))
+    auto_conf = config.get(CONF_AUTO_CALIBRATION, {})
+    cg.add(roode.set_calibration_persistence(auto_conf.get(CONF_PERSIST, False)))
+    cg.add(roode.set_auto_calibration_interval_sec(auto_conf.get(CONF_INTERVAL, 4 * 60 * 60)))
     cg.add(roode.set_filter_mode(config[CONF_FILTER_MODE]))
     cg.add(roode.set_filter_window(config[CONF_FILTER_WINDOW]))
     cg.add(roode.set_log_fallback_events(config[CONF_LOG_FALLBACK]))

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -118,6 +118,10 @@ Roode::~Roode() {
   delete entry;
   delete exit;
 }
+
+void Roode::set_auto_calibration_interval_sec(uint32_t sec) {
+  auto_calibration_interval_sec_ = sec;
+}
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
   ESP_LOGCONFIG(TAG, "  Sample size: %d", samples);

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -119,6 +119,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
   void set_force_single_core(bool val) { force_single_core_ = val; }
   void set_calibration_persistence(bool val) { calibration_persistence_ = val; }
+  void set_auto_calibration_interval_sec(uint32_t sec);
   void set_filter_mode(FilterMode mode) {
     filter_mode_ = mode;
     default_filter_mode_ = mode;

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -86,6 +86,7 @@ roode:
   detection_thresholds: # defaults for both zones. These also default to 0% & 85% as previously done.
     # min: 234mm # absolute distance
     max: 85% # percent based on idle distance
+  auto_calibration: { interval: 14400, persist: false }
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -81,10 +81,11 @@ roode:
   detection_thresholds: # defaults for both zones. These also default to 0% & 85% as previously done.
     # min: 234mm # absolute distance
     max: 85% # percent based on idle distance
+  auto_calibration: { interval: 14400, persist: false }
   zones:
     invert: true
     entry:
-      roi: auto 
+      roi: auto
     exit:
       # roi:
       #   height: 4

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -83,6 +83,7 @@ roode:
   detection_thresholds: # defaults for both zones. These also default to 0% & 85% as previously done.
     # min: 234mm # absolute distance
     max: 85% # percent based on idle distance
+  auto_calibration: { interval: 14400, persist: false }
   # The people counting algorithm works by splitting the sensor's capability reading area into two zones.
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -77,6 +77,7 @@ roode:
   detection_thresholds: # defaults for both zones. These also default to 0% & 85% as previously done.
     # min: 234mm # absolute distance
     max: 85% # percent based on idle distance
+  auto_calibration: { interval: 14400, persist: false }
   zones:
     invert: true
     entry:


### PR DESCRIPTION
## Summary
- add `auto_calibration` schema with interval and persist options
- expose `set_auto_calibration_interval_sec` and map config fields
- document and example updates for new `auto_calibration` block

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abdf8e21ac8330903724fbee23ad25