### PR TITLE
Implement passive scan loops for VL53L1X

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -784,8 +784,35 @@ void Roode::start_passive_scan() {
   for (int grid : grids) {
     for (int trial = 1; trial <= 3; ++trial) {
       for (const char *mode : modes) {
+        const RangingMode *ranging_mode = Ranging::Short;
+        if (strcmp(mode, "medium") == 0)
+          ranging_mode = Ranging::Medium;
+        else if (strcmp(mode, "long") == 0)
+          ranging_mode = Ranging::Long;
+        distanceSensor->set_ranging_mode(ranging_mode);
+
         std::vector<int> mcps(grid * grid, 0);
         std::vector<int> distance(grid * grid, 0);
+
+        ROI roi{4, 4, 0};
+        int spacing = 16 / grid;
+        for (int y = 0; y < grid; ++y) {
+          for (int x = 0; x < grid; ++x) {
+            uint8_t cx = static_cast<uint8_t>(x * spacing + spacing / 2);
+            uint8_t cy = static_cast<uint8_t>(y * spacing + spacing / 2);
+            roi.center = static_cast<uint8_t>((cy * 16) + cx + 1);
+
+            VL53L1_Error status;
+            auto dist = distanceSensor->read_distance(&roi, status);
+            if (dist.has_value()) {
+              auto rate = distanceSensor->read_signal_rate(status);
+              if (rate.has_value())
+                mcps[y * grid + x] = rate.value();
+              distance[y * grid + x] = dist.value();
+            }
+          }
+        }
+
         float mean_mcps = 0.0f;
         for (int v : mcps)
           mean_mcps += v;

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -346,6 +346,24 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
   return {distance};
 }
 
+optional<uint16_t> VL53L1X::read_signal_rate(VL53L1_Error &status) {
+  if (this->is_failed()) {
+    ESP_LOGW(TAG, "Cannot read signal rate while component is failed");
+    record_failure();
+    return {};
+  }
+
+  uint16_t rate = 0;
+  status = this->sensor.GetSignalRate(&rate);
+  if (status != VL53L1_ERROR_NONE) {
+    ESP_LOGE(TAG, "Could not get signal rate, error code: %d", status);
+    record_failure();
+    return {};
+  }
+
+  return {rate};
+}
+
 bool VL53L1X::check_features() {
   ESP_LOGI(TAG, "Validating optional pins");
   bool xshut_ok = false;

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -28,6 +28,7 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   float get_setup_priority() const override { return setup_priority::DATA; };
 
   optional<uint16_t> read_distance(ROI *roi, VL53L1_Error &error);
+  optional<uint16_t> read_signal_rate(VL53L1_Error &error);
   void set_ranging_mode(const RangingMode *mode);
 
   optional<bool> get_xshut_state() {


### PR DESCRIPTION
## Summary
- configure VL53L1X for each grid and ranging mode during passive scan
- read MCPS and distance for every cell and publish as JSON
- expose signal rate helper in VL53L1X driver

## Testing
- `pio run` *(fails: esphome/components headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abdfd42f0c8330a0da32a40e14e646