### PR TITLE
Add passive scan button for Roode

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -3,17 +3,32 @@ import json
 from pathlib import Path
 import esphome.codegen as cg
 import esphome.config_validation as cv
+from esphome.components import button
+from esphome.components.template import button as template_button
 from esphome.const import (
+    CONF_ENTITY_CATEGORY,
     CONF_HEIGHT,
+    CONF_ICON,
     CONF_ID,
     CONF_INVERT,
+    CONF_NAME,
     CONF_SENSOR,
     CONF_WIDTH,
+    ENTITY_CATEGORY_DIAGNOSTIC,
 )
+from esphome.core import ID
 from ..vl53l1x import distance_as_mm, NullableSchema, VL53L1X
 
 DEPENDENCIES = ["vl53l1x"]
-AUTO_LOAD = ["vl53l1x", "sensor", "binary_sensor", "text_sensor", "number"]
+AUTO_LOAD = [
+    "vl53l1x",
+    "sensor",
+    "binary_sensor",
+    "text_sensor",
+    "number",
+    "button",
+    "template",
+]
 MULTI_CONF = True
 
 CONF_ROODE_ID = "roode_id"
@@ -122,6 +137,23 @@ CONFIG_SCHEMA = cv.Schema(
 async def to_code(config: Dict):
     roode = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(roode, config)
+
+    button_id = ID(f"{config[CONF_ID].id}_start_passive_scan")
+    button_id.type = template_button.TemplateButton
+    btn_conf = {
+        CONF_ID: button_id,
+        CONF_NAME: "Start Passive Scan",
+        CONF_ICON: "mdi:radar",
+        CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+    }
+    start_scan_button = await button.new_button(btn_conf)
+    cg.add(
+        start_scan_button.add_on_press_callback(
+            cg.RawExpression(
+                f"std::bind(&{Roode}::start_passive_scan, {roode})"
+            )
+        )
+    )
 
     sens = await cg.get_variable(config[CONF_SENSOR])
     cg.add(roode.set_tof_sensor(sens))

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -26,36 +26,8 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
 
 ## Passive Scan Trigger
 
-Add an `input_select` to request a passive scan session and an
-automation that calls a helper script:
-
-```
-input_select:
-  roode_action:
-    name: Roode Action
-    options:
-      - idle
-      - start_passive_scan
-
-automation:
-  - alias: "Start Roode passive scan"
-    trigger:
-      platform: state
-      entity_id: input_select.roode_action
-      to: "start_passive_scan"
-    action:
-      - service: python_script.start_passive_scan
-        data:
-          device: roode32
-      - service: input_select.select_option
-        target:
-          entity_id: input_select.roode_action
-        data:
-          option: idle
-```
-
-Place `homeassistant/python_scripts/start_passive_scan.py` into your
-Home Assistant configuration. Selecting `start_passive_scan` creates a
+Roode exposes a `Start Passive Scan` button entity that requests a scan
+session directly from the device. Pressing the button creates a
 timestamped `passive_scan_YYYY-MM-DD_HH-MM/` directory with an empty
 `session.json` and dispatches an `esphome.<node>_start_passive_scan`
 command to the ESPHome node.


### PR DESCRIPTION
## Summary
- expose a Start Passive Scan button that calls `start_passive_scan()`
- document the button and remove obsolete Home Assistant automation instructions

## Testing
- `python -m py_compile components/roode/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68abdf8b5218833092054ab4465b0ace