### PR TITLE
Implement adaptive passive scan trials

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -59,6 +59,7 @@ CONF_RESTART_TIMEOUT = "restart_timeout"
 CONF_CPU_OPTIMIZATION = "cpu_optimization"
 CONF_ACTIVATE = "activate"
 CONF_DEACTIVATE = "deactivate"
+CONF_TRIAL_BUMP_CV = "trial_bump_cv"
 CONF_ROI_RESULT = "roi_result"
 
 FilterMode = roode_ns.enum("FilterMode")
@@ -129,6 +130,7 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_DEACTIVATE, default=0.50): cv.percentage,
             }
         ),
+        cv.Optional(CONF_TRIAL_BUMP_CV, default=0.20): cv.percentage,
         cv.Optional(CONF_ROI_RESULT): cv.file_,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
@@ -176,6 +178,7 @@ async def to_code(config: Dict):
     cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
     cg.add(roode.set_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT]))
     cg.add(roode.set_restart_timeout(config[CONF_RESTART_TIMEOUT]))
+    cg.add(roode.set_trial_bump_cv(config[CONF_TRIAL_BUMP_CV] * 100.0))
     cpu_conf = config.get(CONF_CPU_OPTIMIZATION, {})
     cg.add(
         roode.set_cpu_optimization_thresholds(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -119,9 +119,7 @@ Roode::~Roode() {
   delete exit;
 }
 
-void Roode::set_auto_calibration_interval_sec(uint32_t sec) {
-  auto_calibration_interval_sec_ = sec;
-}
+void Roode::set_auto_calibration_interval_sec(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
   ESP_LOGCONFIG(TAG, "  Sample size: %d", samples);
@@ -785,16 +783,19 @@ void Roode::start_passive_scan() {
   scan_record_count_ = 0;
   const std::vector<int> grids{4, 8, 16};
   const char *modes[] = {"short", "medium", "long"};
+  constexpr int base_trials = 3;
+  constexpr int max_trials = 5;
   for (int grid : grids) {
-    for (int trial = 1; trial <= 3; ++trial) {
-      for (const char *mode : modes) {
-        const RangingMode *ranging_mode = Ranging::Short;
-        if (strcmp(mode, "medium") == 0)
-          ranging_mode = Ranging::Medium;
-        else if (strcmp(mode, "long") == 0)
-          ranging_mode = Ranging::Long;
-        distanceSensor->set_ranging_mode(ranging_mode);
+    for (const char *mode : modes) {
+      const RangingMode *ranging_mode = Ranging::Short;
+      if (strcmp(mode, "medium") == 0)
+        ranging_mode = Ranging::Medium;
+      else if (strcmp(mode, "long") == 0)
+        ranging_mode = Ranging::Long;
+      distanceSensor->set_ranging_mode(ranging_mode);
 
+      std::vector<float> cv_trials;
+      for (int trial = 1; trial <= max_trials; ++trial) {
         std::vector<int> mcps(grid * grid, 0);
         std::vector<int> distance(grid * grid, 0);
 
@@ -844,6 +845,7 @@ void Roode::start_passive_scan() {
         float cv_trial = mean_dist != 0.0f ? (sqrtf(var_dist) / mean_dist) * 100.0f : 0.0f;
         if (trial_bump_cv_sensor != nullptr)
           trial_bump_cv_sensor->publish_state(cv_trial);
+        cv_trials.push_back(cv_trial);
 
         std::stringstream mcps_ss;
         mcps_ss << '[';
@@ -873,6 +875,15 @@ void Roode::start_passive_scan() {
         json << ",\"timestamp\":\"" << ts << "\"";
         json << ",\"data\":{\"mcps\":" << mcps_ss.str() << ",\"distance\":" << dist_ss.str() << "}}";
         publish_scan_record(json.str());
+
+        if (trial >= base_trials) {
+          float avg_cv = 0.0f;
+          for (float cv : cv_trials)
+            avg_cv += cv;
+          avg_cv /= cv_trials.size();
+          if (avg_cv <= trial_bump_cv_ || trial == max_trials)
+            break;
+        }
       }
     }
   }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -134,6 +134,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   }
   void set_invalid_distance_limit(uint8_t limit) { invalid_distance_limit_ = limit; }
   void set_restart_timeout(uint32_t ms) { restart_timeout_ms_ = ms; }
+  void set_trial_bump_cv(float cv) { trial_bump_cv_ = cv; }
   void set_cpu_optimization_thresholds(float activate, float deactivate) {
     cpu_opt_activate_threshold_ = activate;
     cpu_opt_deactivate_threshold_ = deactivate;
@@ -209,6 +210,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   int manual_adjustment_count_{0};
   uint32_t scan_start_ts_{0};
   uint32_t scan_record_count_{0};
+  float trial_bump_cv_{20.0f};
 
   void publish_scan_record(const std::string &payload);
   float expected_counter_{0};


### PR DESCRIPTION
## Summary
- add configurable `trial_bump_cv` threshold for passive scan trials
- repeat passive scans up to five trials when CV exceeds threshold

## Testing
- `python -m py_compile components/roode/__init__.py`
- `python -m py_compile components/roode/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68abe25304508330946665d84f632cb1