### PR TITLE
Add configurable scan time cap for passive scans

### DIFF
--- a/Documents/developer_notes.md
+++ b/Documents/developer_notes.md
@@ -9,4 +9,6 @@ Reports the coefficient of variation for the MCPS mask collected during a passiv
 Represents the coefficient of variation for distance measurements observed in each trial of a passive scan. It helps evaluate the stability of bump detection across trials.
 
 ### scan_time_cap_seconds
-Publishes the total elapsed time of the passive scan session in seconds, allowing monitoring of the scan duration.
+Publishes the total elapsed time of the passive scan session in seconds. When a
+`scan_time_cap_seconds` value is configured, the passive scan stops before
+running the 16x16 grid once the elapsed time exceeds this cap.

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -60,6 +60,7 @@ CONF_CPU_OPTIMIZATION = "cpu_optimization"
 CONF_ACTIVATE = "activate"
 CONF_DEACTIVATE = "deactivate"
 CONF_ROI_RESULT = "roi_result"
+CONF_SCAN_TIME_CAP_SECONDS = "scan_time_cap_seconds"
 
 FilterMode = roode_ns.enum("FilterMode")
 FILTER_MODES = {
@@ -123,6 +124,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
         cv.Optional(CONF_INVALID_DISTANCE_LIMIT, default=10): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_RESTART_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=0.0): cv.All(cv.float_, cv.Range(min=0.0)),
         cv.Optional(CONF_CPU_OPTIMIZATION, default={}): cv.Schema(
             {
                 cv.Optional(CONF_ACTIVATE, default=0.90): cv.percentage,
@@ -176,6 +178,7 @@ async def to_code(config: Dict):
     cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
     cg.add(roode.set_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT]))
     cg.add(roode.set_restart_timeout(config[CONF_RESTART_TIMEOUT]))
+    cg.add(roode.set_scan_time_cap_seconds(config[CONF_SCAN_TIME_CAP_SECONDS]))
     cpu_conf = config.get(CONF_CPU_OPTIMIZATION, {})
     cg.add(
         roode.set_cpu_optimization_thresholds(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -119,9 +119,7 @@ Roode::~Roode() {
   delete exit;
 }
 
-void Roode::set_auto_calibration_interval_sec(uint32_t sec) {
-  auto_calibration_interval_sec_ = sec;
-}
+void Roode::set_auto_calibration_interval_sec(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
   ESP_LOGCONFIG(TAG, "  Sample size: %d", samples);
@@ -786,6 +784,14 @@ void Roode::start_passive_scan() {
   const std::vector<int> grids{4, 8, 16};
   const char *modes[] = {"short", "medium", "long"};
   for (int grid : grids) {
+    if (grid == 16 && scan_time_cap_seconds_ > 0) {
+      float elapsed = (millis() - scan_start_ts_) / 1000.0f;
+      if (elapsed > scan_time_cap_seconds_) {
+        ESP_LOGI(TAG, "scan_time_cap_exceeded: %.1fs", elapsed);
+        log_event("scan_time_cap_exceeded");
+        break;
+      }
+    }
     for (int trial = 1; trial <= 3; ++trial) {
       for (const char *mode : modes) {
         const RangingMode *ranging_mode = Ranging::Short;

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -116,6 +116,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void set_variance_cv_mask_sensor(sensor::Sensor *sens) { variance_cv_mask_sensor = sens; }
   void set_trial_bump_cv_sensor(sensor::Sensor *sens) { trial_bump_cv_sensor = sens; }
   void set_scan_time_cap_seconds_sensor(sensor::Sensor *sens) { scan_time_cap_seconds_sensor = sens; }
+  void set_scan_time_cap_seconds(float sec) { scan_time_cap_seconds_ = sec; }
   void set_log_fallback_events(bool val) { log_fallback_events_ = val; }
   void set_force_single_core(bool val) { force_single_core_ = val; }
   void set_calibration_persistence(bool val) { calibration_persistence_ = val; }
@@ -180,6 +181,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   sensor::Sensor *variance_cv_mask_sensor{nullptr};
   sensor::Sensor *trial_bump_cv_sensor{nullptr};
   sensor::Sensor *scan_time_cap_seconds_sensor{nullptr};
+  float scan_time_cap_seconds_{0};
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;


### PR DESCRIPTION
## Summary
- allow configuring a scan_time_cap_seconds limit
- skip the 16x16 grid if passive scan exceeds the cap
- document scan_time_cap_seconds behavior

## Testing
- `python -m py_compile components/roode/__init__.py components/roode/sensor.py`
- `g++ -std=c++17 -Icomponents -Icomponents/roode -Icomponents/vl53l1x -fsyntax-only components/roode/roode.cpp` *(fails: Arduino.h: No such file or directory)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abe256dc208330a3b7d6f1279015c7