### PR TITLE
Add configurable passive scan time cap

### DIFF
--- a/Documents/developer_notes.md
+++ b/Documents/developer_notes.md
@@ -9,4 +9,4 @@ Reports the coefficient of variation for the MCPS mask collected during a passiv
 Represents the coefficient of variation for distance measurements observed in each trial of a passive scan. It helps evaluate the stability of bump detection across trials.
 
 ### scan_time_cap_seconds
-Publishes the total elapsed time of the passive scan session in seconds, allowing monitoring of the scan duration.
+Publishes the total elapsed time of the passive scan session in seconds. Scanning stops before the 16x16 grid when this elapsed time exceeds the configured cap.

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -60,6 +60,7 @@ CONF_CPU_OPTIMIZATION = "cpu_optimization"
 CONF_ACTIVATE = "activate"
 CONF_DEACTIVATE = "deactivate"
 CONF_TRIAL_BUMP_CV = "trial_bump_cv"
+CONF_SCAN_TIME_CAP_SECONDS = "scan_time_cap_seconds"
 CONF_ROI_RESULT = "roi_result"
 
 FilterMode = roode_ns.enum("FilterMode")
@@ -131,6 +132,7 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
         cv.Optional(CONF_TRIAL_BUMP_CV, default=0.20): cv.percentage,
+        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=60.0): cv.positive_float,
         cv.Optional(CONF_ROI_RESULT): cv.file_,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
@@ -179,6 +181,7 @@ async def to_code(config: Dict):
     cg.add(roode.set_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT]))
     cg.add(roode.set_restart_timeout(config[CONF_RESTART_TIMEOUT]))
     cg.add(roode.set_trial_bump_cv(config[CONF_TRIAL_BUMP_CV] * 100.0))
+    cg.add(roode.set_scan_time_cap_seconds(config[CONF_SCAN_TIME_CAP_SECONDS]))
     cpu_conf = config.get(CONF_CPU_OPTIMIZATION, {})
     cg.add(
         roode.set_cpu_optimization_thresholds(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -786,6 +786,13 @@ void Roode::start_passive_scan() {
   constexpr int base_trials = 3;
   constexpr int max_trials = 5;
   for (int grid : grids) {
+    if (grid == 16 && scan_time_cap_seconds_ > 0) {
+      float elapsed = (millis() - scan_start_ts_) / 1000.0f;
+      if (elapsed > scan_time_cap_seconds_) {
+        publish_scan_record("scan_time_cap_reached");
+        break;
+      }
+    }
     for (const char *mode : modes) {
       const RangingMode *ranging_mode = Ranging::Short;
       if (strcmp(mode, "medium") == 0)

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -135,6 +135,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void set_invalid_distance_limit(uint8_t limit) { invalid_distance_limit_ = limit; }
   void set_restart_timeout(uint32_t ms) { restart_timeout_ms_ = ms; }
   void set_trial_bump_cv(float cv) { trial_bump_cv_ = cv; }
+  void set_scan_time_cap_seconds(float sec) { scan_time_cap_seconds_ = sec; }
   void set_cpu_optimization_thresholds(float activate, float deactivate) {
     cpu_opt_activate_threshold_ = activate;
     cpu_opt_deactivate_threshold_ = deactivate;
@@ -211,6 +212,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   uint32_t scan_start_ts_{0};
   uint32_t scan_record_count_{0};
   float trial_bump_cv_{20.0f};
+  float scan_time_cap_seconds_{60.0f};
 
   void publish_scan_record(const std::string &payload);
   float expected_counter_{0};


### PR DESCRIPTION
## Summary
- allow configuring a scan_time_cap_seconds limit for passive scans
- track elapsed time and abort before 16x16 grid when cap exceeded
- document scan_time_cap_seconds behaviour

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8`
- `pytest`
- `pio run` *(fails: esphome headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68abe4aa06148330bd5e547f8d9cb8dc