### PR TITLE
Handle missing disabled_by_default in start scan button

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -10,6 +10,7 @@ from esphome.const import (
     CONF_HEIGHT,
     CONF_ICON,
     CONF_ID,
+    CONF_DISABLED_BY_DEFAULT,
     CONF_INVERT,
     CONF_NAME,
     CONF_SENSOR,
@@ -156,6 +157,7 @@ async def to_code(config: Dict):
         CONF_NAME: "Start Passive Scan",
         CONF_ICON: "mdi:radar",
         CONF_ENTITY_CATEGORY: ENTITY_CATEGORY_DIAGNOSTIC,
+        CONF_DISABLED_BY_DEFAULT: True,
     }
     start_scan_button = await button.new_button(btn_conf)
     cg.add(


### PR DESCRIPTION
## Summary
- register `Start Passive Scan` button as disabled by default to satisfy ESPHome's button config

## Testing
- `python -m py_compile components/roode/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68abe737a4d483308c833a514178716d