### PR TITLE
Fix diagnostic entity category constant for ESPHome 2025

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -157,7 +157,11 @@ async def to_code(config: Dict):
         CONF_DISABLED_BY_DEFAULT: True,
     }
     start_scan_button = await button.new_button(btn_conf)
-    cg.add(start_scan_button.set_entity_category(cg.EntityCategory.DIAGNOSTIC))
+    cg.add(
+        start_scan_button.set_entity_category(
+            cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC
+        )
+    )
     cg.add(
         start_scan_button.add_on_press_callback(
             cg.RawExpression(

--- a/components/roode/sensor.py
+++ b/components/roode/sensor.py
@@ -154,7 +154,9 @@ CONFIG_SCHEMA = sensor.sensor_schema().extend(
 
 async def _new_diagnostic_sensor(conf):
     sens = await sensor.new_sensor(conf)
-    cg.add(sens.set_entity_category(cg.EntityCategory.DIAGNOSTIC))
+    cg.add(
+        sens.set_entity_category(cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC)
+    )
     return sens
 
 

--- a/components/roode/text_sensor.py
+++ b/components/roode/text_sensor.py
@@ -52,7 +52,9 @@ async def setup_conf(config, key, hub):
         conf = config[key]
         sens = cg.new_Pvariable(conf[CONF_ID])
         await text_sensor.register_text_sensor(sens, conf)
-        cg.add(sens.set_entity_category(cg.EntityCategory.DIAGNOSTIC))
+        cg.add(
+            sens.set_entity_category(cg.EntityCategory.ENTITY_CATEGORY_DIAGNOSTIC)
+        )
         cg.add(getattr(hub, f"set_{key}_text_sensor")(sens))
 
 


### PR DESCRIPTION
## Summary
- fix use of DIAGNOSTIC entity category to match updated ESPHome enumeration names

## Testing
- `python -m py_compile components/roode/__init__.py components/roode/sensor.py components/roode/text_sensor.py`
- `flake8 components/roode/__init__.py components/roode/sensor.py components/roode/text_sensor.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abe96d87388330bbd89e97430fed52