### PR TITLE
Guard load_session against non-dict payload

### DIFF
--- a/roi_analysis.py
+++ b/roi_analysis.py
@@ -105,6 +105,9 @@ def load_session(session_dir: Path) -> Dict[Tuple[int, str], ScanGroup]:
                 payload = json.loads(line)
             except json.JSONDecodeError:
                 continue
+            if not isinstance(payload, dict):
+                print(f"Skipping non-dict payload: {payload!r}")
+                continue
             if payload.get("type") != "passive_scan":
                 continue
             grid = int(payload["grid"])


### PR DESCRIPTION
## Summary
- handle non-dict JSON lines when loading sessions

## Testing
- `python -m py_compile roi_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68abec460c388330ba7b14f7256cafe2