### PR TITLE
Enable passive scan button by default

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -154,7 +154,7 @@ async def to_code(config: Dict):
         CONF_ID: button_id,
         CONF_NAME: "Start Passive Scan",
         CONF_ICON: "mdi:radar",
-        CONF_DISABLED_BY_DEFAULT: True,
+        CONF_DISABLED_BY_DEFAULT: False,
     }
     start_scan_button = await button.new_button(btn_conf)
     cg.add(

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -27,7 +27,9 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
 ## Passive Scan Trigger
 
 Roode exposes a `Start Passive Scan` button entity that requests a scan
-session directly from the device. Pressing the button creates a
+session directly from the device. The button is enabled by default, so
+Home Assistant will automatically surface it in the interface. Pressing
+the button creates a
 timestamped `passive_scan_YYYY-MM-DD_HH-MM/` directory with an empty
 `session.json` and dispatches an `esphome.<node>_start_passive_scan`
 command to the ESPHome node.


### PR DESCRIPTION
## Summary
- expose Start Passive Scan button without requiring manual enabling
- document that the calibration trigger appears automatically in Home Assistant

## Testing
- `python -m py_compile components/roode/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68abee2a6fb88330bd7f0632cb457ccc