### PR TITLE
Adjust scan time cap default to 90 seconds

### DIFF
--- a/Documents/developer_notes.md
+++ b/Documents/developer_notes.md
@@ -9,4 +9,4 @@ Reports the coefficient of variation for the MCPS mask collected during a passiv
 Represents the coefficient of variation for distance measurements observed in each trial of a passive scan. It helps evaluate the stability of bump detection across trials.
 
 ### scan_time_cap_seconds
-Publishes the total elapsed time of the passive scan session in seconds. Scanning stops before the 16x16 grid when this elapsed time exceeds the configured cap.
+Publishes the total elapsed time of the passive scan session in seconds. Scanning stops before the 16x16 grid when this elapsed time exceeds the configured cap. Defaults to 90 seconds and supports a safe range from 60 to 180 seconds.

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -118,12 +118,18 @@ CONFIG_SCHEMA = cv.Schema(
                 cv.Optional(CONF_PERSIST, default=False): cv.boolean,
             }
         ),
-        cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(FILTER_MODES, upper=False),
+        cv.Optional(CONF_FILTER_MODE, default="min"): cv.enum(
+            FILTER_MODES, upper=False
+        ),
         cv.Optional(CONF_FILTER_WINDOW, default=5): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_LOG_FALLBACK, default=False): cv.boolean,
         cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
-        cv.Optional(CONF_INVALID_DISTANCE_LIMIT, default=10): cv.All(cv.uint8_t, cv.Range(min=1)),
-        cv.Optional(CONF_RESTART_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
+        cv.Optional(CONF_INVALID_DISTANCE_LIMIT, default=10): cv.All(
+            cv.uint8_t, cv.Range(min=1)
+        ),
+        cv.Optional(
+            CONF_RESTART_TIMEOUT, default="30s"
+        ): cv.positive_time_period_milliseconds,
         cv.Optional(CONF_CPU_OPTIMIZATION, default={}): cv.Schema(
             {
                 cv.Optional(CONF_ACTIVATE, default=0.90): cv.percentage,
@@ -131,7 +137,9 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
         cv.Optional(CONF_TRIAL_BUMP_CV, default=0.20): cv.percentage,
-        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=60.0): cv.positive_float,
+        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=90.0): cv.All(
+            cv.positive_float, cv.Range(min=60.0, max=180.0)
+        ),
         cv.Optional(CONF_ROI_RESULT): cv.file_,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
@@ -164,9 +172,7 @@ async def to_code(config: Dict):
     )
     cg.add(
         start_scan_button.add_on_press_callback(
-            cg.RawExpression(
-                f"std::bind(&{Roode}::start_passive_scan, {roode})"
-            )
+            cg.RawExpression(f"std::bind(&{Roode}::start_passive_scan, {roode})")
         )
     )
 
@@ -177,7 +183,11 @@ async def to_code(config: Dict):
     cg.add(roode.set_sampling_size(config[CONF_SAMPLING]))
     auto_conf = config.get(CONF_AUTO_CALIBRATION, {})
     cg.add(roode.set_calibration_persistence(auto_conf.get(CONF_PERSIST, False)))
-    cg.add(roode.set_auto_calibration_interval_sec(auto_conf.get(CONF_INTERVAL, 4 * 60 * 60)))
+    cg.add(
+        roode.set_auto_calibration_interval_sec(
+            auto_conf.get(CONF_INTERVAL, 4 * 60 * 60)
+        )
+    )
     cg.add(roode.set_filter_mode(config[CONF_FILTER_MODE]))
     cg.add(roode.set_filter_window(config[CONF_FILTER_WINDOW]))
     cg.add(roode.set_log_fallback_events(config[CONF_LOG_FALLBACK]))

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -212,7 +212,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   uint32_t scan_start_ts_{0};
   uint32_t scan_record_count_{0};
   float trial_bump_cv_{20.0f};
-  float scan_time_cap_seconds_{60.0f};
+  float scan_time_cap_seconds_{90.0f};
 
   void publish_scan_record(const std::string &payload);
   float expected_counter_{0};


### PR DESCRIPTION
## Summary
- raise `scan_time_cap_seconds_` default to 90 seconds in Roode component
- restrict `scan_time_cap_seconds` option to 60–180 seconds and document default
- note new 90s default and 60–180s safe range in developer docs

## Testing
- `python -m py_compile components/roode/__init__.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abf0557ed4833097b256f3f7210de4