### PR TITLE
Increase passive scan time cap default

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -131,7 +131,7 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
         cv.Optional(CONF_TRIAL_BUMP_CV, default=0.20): cv.percentage,
-        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=60.0): cv.positive_float,
+        cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=90.0): cv.positive_float,
         cv.Optional(CONF_ROI_RESULT): cv.file_,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -212,7 +212,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   uint32_t scan_start_ts_{0};
   uint32_t scan_record_count_{0};
   float trial_bump_cv_{20.0f};
-  float scan_time_cap_seconds_{60.0f};
+  float scan_time_cap_seconds_{90.0f};
 
   void publish_scan_record(const std::string &payload);
   float expected_counter_{0};


### PR DESCRIPTION
## Summary
- raise default passive scan time cap to 90 seconds
- update configuration schema to match

## Testing
- `pre-commit run --files components/roode/roode.h components/roode/__init__.py` *(fails: .pre-commit-config.yaml is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6e4c2e1c8330b7de3460363263cc