### PR TITLE
Set cv-mask default and enforce safe range

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,7 +705,7 @@ these sensors.
 1. In Home Assistant expose an `input_select` like `roode_action` with a `start_passive_scan` option.
 2. An automation calls the `python_script.start_passive_scan` helper, sending `esphome.<node>_start_passive_scan` to the device.
 3. Run `session_recorder.py` to log WebSocket output into a timestamped `calibration_*/session.json` directory.
-4. After the scan, process the session folder with `roi_analysis.py` to produce an `roi_result.json` file.  Advanced options like `--imbalance-ratio`, `--no-retry-axis`, and `--no-retry-roi` control how the script handles imbalanced zone clustering.  Thresholds are derived from the idle median: the minimum is clamped between 92–96 % of the idle distance and the maximum is at least 10 % above the minimum.  These factors can be tuned with `--idle-min-low`, `--idle-min-high`, and `--max-delta-factor` or a configuration file.
+4. After the scan, process the session folder with `roi_analysis.py` to produce an `roi_result.json` file.  Advanced options like `--imbalance-ratio`, `--no-retry-axis`, and `--no-retry-roi` control how the script handles imbalanced zone clustering.  Use `--cv-mask` to set the coefficient of variation threshold (default 0.25, allowable range 0.15–0.35).  Thresholds are derived from the idle median: the minimum is clamped between 92–96 % of the idle distance and the maximum is at least 10 % above the minimum.  These factors can be tuned with `--idle-min-low`, `--idle-min-high`, and `--max-delta-factor` or a configuration file.
 5. Use `apply_roi_result.py` to copy the result into Home Assistant so a build like `ota_roi_update.yaml` can include it.
 6. Compile and upload the new firmware; Roode applies the updated ROI automatically.
 

--- a/roi_analysis.py
+++ b/roi_analysis.py
@@ -141,17 +141,18 @@ def stable_mask(
     mean, var:
         Per-SPAD mean and variance arrays.
     cv_limit:
-        Explicit CV threshold. If ``None`` the threshold is determined using
-        :func:`cv_threshold` with ``mad_factor``.
+        Explicit CV threshold. Defaults to ``0.25`` when ``None``.  Values
+        outside the ``0.15``–``0.35`` range raise :class:`ValueError`.
     mad_factor:
-        Multiplier for MAD when deriving ``cv_limit`` if not supplied. Typical
-        range is 0.1–2.0.
+        Deprecated; retained for backward compatibility and ignored.
     """
 
     with np.errstate(divide="ignore", invalid="ignore"):
         cv = np.sqrt(var) / mean
     if cv_limit is None:
-        cv_limit = cv_threshold(cv, mad_factor)
+        cv_limit = 0.25
+    if not 0.15 <= cv_limit <= 0.35:
+        raise ValueError("cv_limit must be between 0.15 and 0.35")
 
     med = np.median(mean)
     mad = np.median(np.abs(mean - med))
@@ -329,7 +330,12 @@ def analyze(
     ----------
     groups:
         Mapping of grid/mode combinations to collected scan data.
-    mad_factor, cv_limit, imbalance_ratio, retry_axis, retry_roi:
+    mad_factor:
+        Placeholder for backward compatibility; unused.
+    cv_limit:
+        Coefficient-of-variation threshold. Defaults to ``0.25`` and must be
+        within ``0.15``–``0.35``.
+    imbalance_ratio, retry_axis, retry_roi:
         Existing tuning parameters for ROI selection.
     idle_min_lo, idle_min_hi:
         Clamp factors for the idle median when computing the minimum threshold.
@@ -445,8 +451,8 @@ def main() -> None:
     parser.add_argument(
         "--cv-mask",
         type=float,
-        default=None,
-        help="Explicit CV threshold (0-1); overrides MAD-based threshold",
+        default=0.25,
+        help="Explicit CV threshold (0.15-0.35). Default 0.25.",
     )
     parser.add_argument(
         "--imbalance-ratio",


### PR DESCRIPTION
## Summary
- default `--cv-mask` to 0.25 and document safe range
- validate `stable_mask` CV limits and update docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac6e4fceac8330b258d48529047e3e