### PR TITLE
Use 95th percentile of idle distance for ROI threshold

### DIFF
--- a/roi_analysis.py
+++ b/roi_analysis.py
@@ -245,9 +245,13 @@ def thresholds_from_idle(
 
     dist_arr = np.concatenate([s for s in idle_distances])
     idle_median = float(np.median(dist_arr))
-
+    # Estimate the minimum threshold from the 95th percentile of idle distance
+    # samples and clamp it to a safe range relative to the idle median.
     min_candidate = float(np.percentile(dist_arr, 95))
-    min_th = float(np.clip(min_candidate / idle_median, min_idle_lo, min_idle_hi))
+    min_candidate = float(
+        np.clip(min_candidate, min_idle_lo * idle_median, min_idle_hi * idle_median)
+    )
+    min_th = min_candidate / idle_median
 
     max_th = min_th + 0.10
     if idle_mcps and snr_values:


### PR DESCRIPTION
## Summary
- derive minimum threshold from 95th percentile of idle distance samples
- clamp min threshold between 92% and 96% of idle distance median

## Testing
- `python -m py_compile roi_analysis.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac72a4885083309350265f896d1b62