### PR TITLE
Use optional ROI cache

### DIFF
--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -210,7 +210,7 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
     return {};
   }
 
-  if (last_roi == nullptr || *roi != *last_roi) {
+  if (!last_roi_.has_value() || *roi != last_roi_.value()) {
     status = this->sensor.SetROI(roi->width, roi->height);
     if (status != VL53L1_ERROR_NONE) {
       ESP_LOGE(TAG, "Could not set ROI width/height, error code: %d", status);
@@ -223,7 +223,7 @@ optional<uint16_t> VL53L1X::read_distance(ROI *roi, VL53L1_Error &status) {
       record_failure();
       return {};
     }
-    last_roi = roi;
+    last_roi_ = *roi;
   }
 
   // Decide whether we can use the interrupt pin for this reading

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -3,6 +3,7 @@
 
 #include "VL53L1X_ULD.h"
 #include <vector>
+#include <optional>
 #include "esphome/components/i2c/i2c.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
@@ -67,8 +68,8 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   optional<int16_t> offset{};
   optional<uint16_t> xtalk{};
   uint16_t timeout{};
- ROI *last_roi{};
- int recovery_count_{0};
+  std::optional<ROI> last_roi_;
+  int recovery_count_{0};
   uint8_t sensor_id_{0};
   uint8_t desired_address_{0x29};
   static std::vector<VL53L1X *> sensors;


### PR DESCRIPTION
## Summary
- cache last ROI value with std::optional
- refresh ROI when zone settings change

## Testing
- `pio run` *(fails: esphome/components/... missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ad127de7ec8330a638b14c2dacda4d