### PR TITLE
Add built-in recalibration button

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ calibration workflow in Home Assistant without any coding knowledge:
 4. **Install helper scripts**: copy `homeassistant/python_scripts/start_passive_scan.py`
    and `homeassistant/python_scripts/apply_roi_result.py` into the
    `python_scripts/` directory of Home Assistant.
-5. **Restart Home Assistant**. A new *Roode* dashboard with a *Start Scan*
-   button appears.
+5. **Restart Home Assistant**. A new *Roode* dashboard with *Start Scan* and
+   *Recalibrate* buttons appears.
 6. **Run a scan**: press *Start Scan*, walk through the doorway once, and wait
    until the dashboard shows the result.
 7. **Accept the result**: click *Accept ROI* to apply the automatically
@@ -649,6 +649,7 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | Metrics sensors | Optional sensors report loop time, CPU usage, RAM and flash usage |
 | Fail-safe recalibration | Triggers recalibration if a zone stays active too long |
 | Persistent calibration | Calibration data can persist in flash across reboots |
+| Manual recalibration button | Exposes a `Recalibrate` button for on-demand calibration |
 | Dual-core tasking | Keeps polling responsive on ESP32 with automatic retry/fallback |
 | Filtering options | Median/percentile filters smooth jitter with adjustable window |
 | FSM timeouts | Resets the state machine when a transition stalls |

--- a/ci/common.yaml
+++ b/ci/common.yaml
@@ -13,11 +13,6 @@ button:
   - platform: restart
     name: $friendly_name Restart
     entity_category: config
-  - platform: template
-    name: $friendly_name Recalibrate
-    on_press:
-      - lambda: id(roode_platform)->recalibration();
-    entity_category: config
 
 number:
   - platform: roode

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -181,6 +181,26 @@ async def to_code(config: Dict):
         )
     )
 
+    button_id = ID(f"{config[CONF_ID].id}_recalibrate")
+    button_id.type = template_button.TemplateButton
+    btn_conf = {
+        CONF_ID: button_id,
+        CONF_NAME: "Recalibrate",
+        CONF_ICON: "mdi:restart",
+        CONF_DISABLED_BY_DEFAULT: False,
+    }
+    recalibration_button = await button.new_button(btn_conf)
+    cg.add(
+        recalibration_button.set_entity_category(
+            cg.EntityCategory.ENTITY_CATEGORY_CONFIG
+        )
+    )
+    cg.add(
+        recalibration_button.add_on_press_callback(
+            cg.RawExpression(f"std::bind(&{Roode}::recalibration, {roode})")
+        )
+    )
+
     sens = await cg.get_variable(config[CONF_SENSOR])
     cg.add(roode.set_tof_sensor(sens))
 

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -1,6 +1,5 @@
-To make all functions of Roode work with home assistant you need to set up a few entities and automations. 
-Roode has endpoints to set the count value, reset the counter to 0 and to recalibrate. Unfortunately its not possible to expose buttons via ESPHome that do just that.
-
+To make all functions of Roode work with home assistant you need to set up a few entities and automations.
+Roode now exposes button entities to start a passive scan or force a recalibration, so no manual template buttons are required.
 ```
 # This automation script runs when the counter has changed.
 # It sets the value slider on the GUI. This slides also had its own automation when the value is changed.
@@ -26,13 +25,14 @@ Roode has endpoints to set the count value, reset the counter to 0 and to recali
 
 ## Passive Scan Trigger
 
-Roode exposes a `Start Passive Scan` button entity that requests a scan
-session directly from the device. The button is enabled by default, so
-Home Assistant will automatically surface it in the interface. Pressing
-the button creates a
+Roode exposes `Start Passive Scan` and `Recalibrate` button entities that
+request a scan session or rerun the calibration directly from the device.
+Both buttons are enabled by default, so Home Assistant will automatically
+surface them in the interface. Pressing the scan button creates a
 timestamped `passive_scan_YYYY-MM-DD_HH-MM/` directory with an empty
 `session.json` and dispatches an `esphome.<node>_start_passive_scan`
-command to the ESPHome node.
+command to the ESPHome node. The `Recalibrate` button immediately invokes
+the device's calibration routine.
 
 ## Calibration Dashboard
 

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -96,11 +96,6 @@ button:
   - platform: restart
     name: $friendly_name Restart
     entity_category: config
-  - platform: template
-    name: $friendly_name Recalibrate
-    on_press:
-      - lambda: id(roode_platform)->recalibration();
-    entity_category: config
 
 number:
   - platform: roode

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -98,11 +98,6 @@ button:
   - platform: restart
     name: $friendly_name Restart
     entity_category: config
-  - platform: template
-    name: $friendly_name Recalibrate
-    on_press:
-      - lambda: id(roode_platform)->recalibration();
-    entity_category: config
 
 number:
   - platform: roode

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -93,11 +93,6 @@ button:
   - platform: restart
     name: $friendly_name Restart
     entity_category: config
-  - platform: template
-    name: $friendly_name Recalibrate
-    on_press:
-      - lambda: id(roode_platform)->recalibration();
-    entity_category: config
 
 number:
   - platform: roode

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -94,11 +94,6 @@ button:
   - platform: restart
     name: $friendly_name Restart
     entity_category: config
-  - platform: template
-    name: $friendly_name Recalibrate
-    on_press:
-      - lambda: id(roode_platform)->recalibration();
-    entity_category: config
 
 number:
   - platform: roode


### PR DESCRIPTION
## Summary
- add automatic `Recalibrate` button to Roode component
- remove manual `Recalibrate` buttons from sample configurations
- document the new button in Home Assistant and README guides

## Testing
- `python -m compileall components/roode/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad12cae4188330bef02ecbda0ae70a