### PR TITLE
Feed watchdog during zone calibration

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -528,6 +528,8 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
     calibration_prefs_[zone_id].save(&calibration_data_[zone_id]);
   }
 
+  App.feed_wdt();
+
   // Publish the updated calibration data so Home Assistant sees the new
   // thresholds and ROI values immediately after a fail-safe recalibration
   publish_sensor_configuration(entry, exit, true);


### PR DESCRIPTION
## Summary
- feed WDT after zone recalibration to prevent watchdog timeouts

## Testing
- `platformio run` *(fails: esphome/components/binary_sensor/binary_sensor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad17eeffb4833082761535d5095ab7