### PR TITLE
Remove obsolete presence sensor validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,11 @@ calibration:6:01PM
 | `enabled_features` | text_sensor | List of active runtime features |
 
 
+Presence sensors are enabled simply by defining the `presence_sensor` option in
+the YAML configuration. There is no separate toggle or final validation step
+required for this sensor.
+
+
 ### Threshold distance
 
 A crossing is detected when the measured distance for a zone falls between its

--- a/components/roode/binary_sensor.py
+++ b/components/roode/binary_sensor.py
@@ -1,11 +1,8 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import binary_sensor
-import esphome.final_validate as fv
 from esphome.const import (
     CONF_ID,
-    CONF_DEVICE_CLASS,
-    DEVICE_CLASS_OCCUPANCY,
 )
 from . import Roode, CONF_ROODE_ID
 
@@ -33,22 +30,8 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
     }
+
 )
-
-
-# def validate_can_use_presence(value):
-#     main = fv.full_config.get()["roode"][0]
-#     presence_sensor = main.get(CONF_USE_PRESENCE)
-#     print(presence_sensor)
-#     if presence_sensor == False:
-#         raise cv.Invalid("Presence sensor is not enabled")
-#     else:
-#         return presence_sensor
-
-
-# FINAL_VALIDATE_SCHEMA = cv.Schema(
-#     {cv.Optional(CONF_PRESENCE): validate_can_use_presence}, extra=cv.ALLOW_EXTRA
-# )
 
 
 async def setup_conf(config, key, hub):


### PR DESCRIPTION
## Summary
- remove commented presence sensor validation code
- document that `presence_sensor` requires no extra validation

## Testing
- `python -m py_compile components/roode/binary_sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad2650b07c83309ad1a47d720b1404