### PR TITLE
fix: remove GNU elvis operator

### DIFF
--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -65,9 +65,9 @@ VL53L1_Error Zone::readDistance(TofSensor *distanceSensor) {
  * This is needed to do initial calibration of thresholds & ROI.
  */
 void Zone::reset_roi(uint8_t default_center) {
-  roi->width = roi_override->width ?: 6;
-  roi->height = roi_override->height ?: 16;
-  roi->center = roi_override->center ?: default_center;
+  roi->width = roi_override->width ? roi_override->width : 6;
+  roi->height = roi_override->height ? roi_override->height : 16;
+  roi->center = roi_override->center ? roi_override->center : default_center;
   ESP_LOGD(TAG, "%s ROI reset: { width: %d, height: %d, center: %d }", id == 0U ? "Entry" : "Exit", roi->width,
            roi->height, roi->center);
 }
@@ -111,8 +111,8 @@ void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Or
   // center of the two zones
   int function_of_the_distance = 16 * (1 - (0.15 * 2) / (0.34 * (min(entry_threshold, exit_threshold) / 1000)));
   int ROI_size = min(8, max(4, function_of_the_distance));
-  this->roi->width = this->roi_override->width ?: ROI_size;
-  this->roi->height = this->roi_override->height ?: ROI_size * 2;
+  this->roi->width = this->roi_override->width ? this->roi_override->width : ROI_size;
+  this->roi->height = this->roi_override->height ? this->roi_override->height : ROI_size * 2;
   if (this->roi_override->center) {
     this->roi->center = this->roi_override->center;
   } else {


### PR DESCRIPTION
## Summary
- replace GNU elvis operator `?:` with explicit ternary expressions for width, height, and center overrides

## Testing
- `esphome compile peopleCounter32Dev_tmp.yaml` *(fails: Unknown pin mode OUTPUT_PULLUP)*
- `g++ -std=c++17 -Icomponents -I/tmp/stub -I/tmp/stub/components/vl53l1x -c components/roode/zone.cpp -o /tmp/zone.o` *(fails: VL53L1X_ULD.h: No such file or directory)*
- `clang++ -std=c++17 -Icomponents -I/tmp/stub -I/tmp/stub/components/vl53l1x -c components/roode/zone.cpp -o /tmp/zone.o` *(fails: command not found: clang++)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2650057c833090e497a3974cd537