### PR TITLE
Remove duplicate xshut state setter

### DIFF
--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -106,7 +106,6 @@ class Roode : public PollingComponent {
   void set_entry_exit_event_text_sensor(text_sensor::TextSensor *entry_exit_event_sensor_) {
     entry_exit_event_sensor = entry_exit_event_sensor_;
   }
-  void set_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
   void set_sensor_xshut_state_binary_sensor(binary_sensor::BinarySensor *sens) { xshut_state_binary_sensor = sens; }
   void set_interrupt_status_sensor(sensor::Sensor *sens) { interrupt_status_sensor = sens; }
   void set_enabled_features_text_sensor(text_sensor::TextSensor *sensor_) { enabled_features_sensor = sensor_; }


### PR DESCRIPTION
## Summary
- remove legacy `set_xshut_state_binary_sensor` duplicate

## Testing
- `python -m py_compile components/roode/binary_sensor.py`
- `rg set_xshut_state_binary_sensor -n`

------
https://chatgpt.com/codex/tasks/task_e_68ad264f8a9c833093e096ea67a5256c