### PR TITLE
Add ESP32-C3 PlatformIO environment

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,3 +10,13 @@ lib_dir = .esphome/build/roode32dev/.piolibdeps/roode32dev
 framework = arduino
 board = nodemcu-32s
 platform = platformio/espressif32 @ 3.3.2
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17
+
+[env:roode-c3]
+framework = arduino
+board = esp32-c3-devkitm-1
+platform = platformio/espressif32 @ 6.6.0
+build_unflags = -std=gnu++11
+build_flags = -std=gnu++17
+lib_ignore = AsyncTCP, ESPAsyncWebServer, RPAsyncTCP


### PR DESCRIPTION
## Summary
- add PlatformIO `roode-c3` environment for esp32-c3-devkitm-1 board
- enable C++17 and ignore incompatible async libraries

## Testing
- `pio run -e roode-c3` *(fails: undefined reference to `esphome::millis()` and other symbols)*


------
https://chatgpt.com/codex/tasks/task_e_68ad2e64d54c833091de4794c2154114