### PR TITLE
Add management portal toggle

### DIFF
--- a/comingsoon.js
+++ b/comingsoon.js
@@ -1,0 +1,3 @@
+document.addEventListener("DOMContentLoaded", () => {
+  document.body.innerHTML = "<h1>Coming Soon</h1>";
+});

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -11,6 +11,10 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: 'id(management_portal_base).deinit();'
 
 esp32:
   board: wemos_d1_mini32
@@ -43,7 +47,11 @@ ota:
   password: !secret ota_password
 
 web_server:
+  id: management_portal_server
+  web_server_base_id: management_portal_base
   port: 80
+  js_include: comingsoon.js
+  js_url: ""
   auth:
     username: admin
     password: !secret web_password
@@ -91,6 +99,15 @@ roode:
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:
     invert: true
+
+switch:
+  - platform: template
+    id: management_portal_switch
+    name: $friendly_name Management Portal
+    turn_on_action:
+      - lambda: 'id(management_portal_base).init();'
+    turn_off_action:
+      - lambda: 'id(management_portal_base).deinit();'
 
 button:
   - platform: restart

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -8,6 +8,10 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: 'id(management_portal_base).deinit();'
 
 esp32:
   board: wemos_d1_mini32
@@ -40,7 +44,11 @@ ota:
   password: !secret ota_password
 
 web_server:
+  id: management_portal_server
+  web_server_base_id: management_portal_base
   port: 80
+  js_include: comingsoon.js
+  js_url: ""
   auth:
     username: admin
     password: !secret web_password
@@ -93,6 +101,15 @@ roode:
       #   center: 124
       detection_thresholds:
         max: 70% # override max for exit zone
+
+switch:
+  - platform: template
+    id: management_portal_switch
+    name: $friendly_name Management Portal
+    turn_on_action:
+      - lambda: 'id(management_portal_base).init();'
+    turn_off_action:
+      - lambda: 'id(management_portal_base).deinit();'
 
 button:
   - platform: restart

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -11,6 +11,10 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: 'id(management_portal_base).deinit();'
   platform: ESP8266
   board: d1_mini
 
@@ -40,7 +44,11 @@ ota:
   password: !secret ota_password
 
 web_server:
+  id: management_portal_server
+  web_server_base_id: management_portal_base
   port: 80
+  js_include: comingsoon.js
+  js_url: ""
   auth:
     username: admin
     password: !secret web_password
@@ -88,6 +96,15 @@ roode:
   # This allows for detecting whether a crossing is an entry or exit based on which zones was crossed first.
   zones:
     invert: true
+
+switch:
+  - platform: template
+    id: management_portal_switch
+    name: $friendly_name Management Portal
+    turn_on_action:
+      - lambda: 'id(management_portal_base).init();'
+    turn_off_action:
+      - lambda: 'id(management_portal_base).deinit();'
 
 button:
   - platform: restart

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -8,6 +8,10 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    priority: 600
+    then:
+      - lambda: 'id(management_portal_base).deinit();'
   platform: ESP8266
   board: d1_mini
 
@@ -37,7 +41,11 @@ ota:
   password: !secret ota_password
 
 web_server:
+  id: management_portal_server
+  web_server_base_id: management_portal_base
   port: 80
+  js_include: comingsoon.js
+  js_url: ""
   auth:
     username: admin
     password: !secret web_password
@@ -89,6 +97,15 @@ roode:
       #   center: 124
       # detection_thresholds:
       #   max: 70% # override max for exit zone
+
+switch:
+  - platform: template
+    id: management_portal_switch
+    name: $friendly_name Management Portal
+    turn_on_action:
+      - lambda: 'id(management_portal_base).init();'
+    turn_off_action:
+      - lambda: 'id(management_portal_base).deinit();'
 
 button:
   - platform: restart


### PR DESCRIPTION
## Summary
- add Management Portal switch to ESP32/ESP8266 configs
- serve simple 'Coming Soon' page and allow toggling web server on demand

## Testing
- `esphome config peopleCounter32.yaml` *(fails: [interrupt_status] is an invalid option for [sensor.roode])*

------
https://chatgpt.com/codex/tasks/task_e_68ae4a16a8808330a8767876f053b41a