### PR TITLE
Add portal switch and server controls

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -125,6 +125,135 @@ Roode::~Roode() {
   delete exit;
 }
 
+void Roode::register_server_endpoints() {
+#ifdef USE_WEB_SERVER
+  if (portal_registered_ || web_server_base::global_web_server_base == nullptr)
+    return;
+  auto server = web_server_base::global_web_server_base->get_server();
+  portal_registered_ = true;
+
+  server->on("/api/settings/current", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(256);
+    doc["samples"] = samples;
+    doc["filter_window"] = filter_window_;
+    doc["filter_mode"] = static_cast<int>(filter_mode_);
+    JsonObject entry_roi = doc.createNestedObject("entry_roi");
+    entry_roi["center"] = entry->roi->center;
+    entry_roi["width"] = entry->roi->width;
+    entry_roi["height"] = entry->roi->height;
+    JsonObject exit_roi = doc.createNestedObject("exit_roi");
+    exit_roi["center"] = exit->roi->center;
+    exit_roi["width"] = exit->roi->width;
+    exit_roi["height"] = exit->roi->height;
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/scan/status", HTTP_GET, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(64);
+    doc["running"] = scan_running;
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/scan/start", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    if (!scan_running) {
+      scan_cancel_requested = false;
+      scan_running = true;
+      this->start_passive_scan();
+      scan_running = false;
+      DynamicJsonDocument doc(64);
+      doc["started"] = true;
+      std::string out;
+      serializeJson(doc, out);
+      request->send(200, "application/json", out.c_str());
+    } else {
+      DynamicJsonDocument doc(64);
+      doc["started"] = false;
+      std::string out;
+      serializeJson(doc, out);
+      request->send(200, "application/json", out.c_str());
+    }
+  });
+
+  server->on("/api/scan/cancel", HTTP_POST, [](AsyncWebServerRequest *request) {
+    scan_cancel_requested = true;
+    DynamicJsonDocument doc(64);
+    doc["cancelled"] = true;
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/roi/preview", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(256);
+    JsonObject entry_roi = doc.createNestedObject("entry_roi");
+    entry_roi["center"] = entry->roi->center;
+    entry_roi["width"] = entry->roi->width;
+    entry_roi["height"] = entry->roi->height;
+    JsonObject exit_roi = doc.createNestedObject("exit_roi");
+    exit_roi["center"] = exit->roi->center;
+    exit_roi["width"] = exit->roi->width;
+    exit_roi["height"] = exit->roi->height;
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/roi/apply", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    this->recalibration();
+    DynamicJsonDocument doc(64);
+    doc["applied"] = true;
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/scan/sessions", HTTP_GET, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(64);
+    doc.createNestedArray("sessions");
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on(UriRegex("^/api/scan/session/(.+)$"), HTTP_GET, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(128);
+    doc["id"] = request->pathArg(0).c_str();
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/scan/delete", HTTP_POST, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(64);
+    doc["deleted"] = true;
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+
+  server->on("/api/export/all", HTTP_GET, [](AsyncWebServerRequest *request) {
+    DynamicJsonDocument doc(64);
+    doc["export"] = "all";
+    std::string out;
+    serializeJson(doc, out);
+    request->send(200, "application/json", out.c_str());
+  });
+#endif
+}
+
+void Roode::start_portal() {
+  portal_enabled_ = true;
+#ifdef USE_WEB_SERVER
+  register_server_endpoints();
+#endif
+}
+
+void Roode::stop_portal() { portal_enabled_ = false; }
+
 void Roode::set_auto_calibration_interval_sec(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
@@ -143,119 +272,8 @@ void Roode::setup() {
   this->register_service(&Roode::start_passive_scan, "start_passive_scan");
 #endif
 #ifdef USE_WEB_SERVER
-  if (web_server_base::global_web_server_base != nullptr) {
-    auto server = web_server_base::global_web_server_base->get_server();
-
-    server->on("/api/settings/current", HTTP_GET, [this](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(256);
-      doc["samples"] = samples;
-      doc["filter_window"] = filter_window_;
-      doc["filter_mode"] = static_cast<int>(filter_mode_);
-      JsonObject entry_roi = doc.createNestedObject("entry_roi");
-      entry_roi["center"] = entry->roi->center;
-      entry_roi["width"] = entry->roi->width;
-      entry_roi["height"] = entry->roi->height;
-      JsonObject exit_roi = doc.createNestedObject("exit_roi");
-      exit_roi["center"] = exit->roi->center;
-      exit_roi["width"] = exit->roi->width;
-      exit_roi["height"] = exit->roi->height;
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/scan/status", HTTP_GET, [](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(64);
-      doc["running"] = scan_running;
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/scan/start", HTTP_POST, [this](AsyncWebServerRequest *request) {
-      if (!scan_running) {
-        scan_cancel_requested = false;
-        scan_running = true;
-        this->start_passive_scan();
-        scan_running = false;
-        DynamicJsonDocument doc(64);
-        doc["started"] = true;
-        std::string out;
-        serializeJson(doc, out);
-        request->send(200, "application/json", out.c_str());
-      } else {
-        DynamicJsonDocument doc(64);
-        doc["started"] = false;
-        std::string out;
-        serializeJson(doc, out);
-        request->send(200, "application/json", out.c_str());
-      }
-    });
-
-    server->on("/api/scan/cancel", HTTP_POST, [](AsyncWebServerRequest *request) {
-      scan_cancel_requested = true;
-      DynamicJsonDocument doc(64);
-      doc["cancelled"] = true;
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/roi/preview", HTTP_GET, [this](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(256);
-      JsonObject entry_roi = doc.createNestedObject("entry_roi");
-      entry_roi["center"] = entry->roi->center;
-      entry_roi["width"] = entry->roi->width;
-      entry_roi["height"] = entry->roi->height;
-      JsonObject exit_roi = doc.createNestedObject("exit_roi");
-      exit_roi["center"] = exit->roi->center;
-      exit_roi["width"] = exit->roi->width;
-      exit_roi["height"] = exit->roi->height;
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/roi/apply", HTTP_POST, [this](AsyncWebServerRequest *request) {
-      this->recalibration();
-      DynamicJsonDocument doc(64);
-      doc["applied"] = true;
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/scan/sessions", HTTP_GET, [](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(64);
-      doc.createNestedArray("sessions");
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on(UriRegex("^/api/scan/session/(.+)$"), HTTP_GET, [](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(128);
-      doc["id"] = request->pathArg(0).c_str();
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/scan/delete", HTTP_POST, [](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(64);
-      doc["deleted"] = true;
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
-
-    server->on("/api/export/all", HTTP_GET, [](AsyncWebServerRequest *request) {
-      DynamicJsonDocument doc(64);
-      doc["export"] = "all";
-      std::string out;
-      serializeJson(doc, out);
-      request->send(200, "application/json", out.c_str());
-    });
+  if (portal_enabled_) {
+    register_server_endpoints();
   }
 #endif
   if (version_sensor != nullptr) {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -152,6 +152,9 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   Zone *exit = new Zone(1);
   static void log_event(const std::string &msg);
 
+  void start_portal();
+  void stop_portal();
+
  protected:
   TofSensor *distanceSensor;
   Zone *current_zone = entry;
@@ -182,6 +185,10 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   sensor::Sensor *variance_cv_mask_sensor{nullptr};
   sensor::Sensor *trial_bump_cv_sensor{nullptr};
   sensor::Sensor *scan_time_cap_seconds_sensor{nullptr};
+
+  void register_server_endpoints();
+  bool portal_enabled_{false};
+  bool portal_registered_{false};
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -11,6 +11,17 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    then:
+      - if:
+          condition:
+            lambda: 'return id(portal_on);'
+          then:
+            - lambda: 'id(roode_platform).start_portal();'
+            - web_server.start:
+          else:
+            - web_server.stop:
+            - lambda: 'id(roode_platform).stop_portal();'
 
 esp32:
   board: wemos_d1_mini32
@@ -47,6 +58,29 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
+
+globals:
+  - id: portal_on
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+switch:
+  - platform: template
+    id: portal_switch
+    name: Portal
+    lambda: |-
+      return id(portal_on);
+    turn_on_action:
+      - lambda: |-
+          id(portal_on) = true;
+          id(roode_platform).start_portal();
+      - web_server.start:
+    turn_off_action:
+      - lambda: |-
+          id(portal_on) = false;
+          id(roode_platform).stop_portal();
+      - web_server.stop:
 
 # Enable logging
 logger:

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -8,6 +8,17 @@ external_components:
 
 esphome:
   name: $devicename
+  on_boot:
+    then:
+      - if:
+          condition:
+            lambda: 'return id(portal_on);'
+          then:
+            - lambda: 'id(roode_platform).start_portal();'
+            - web_server.start:
+          else:
+            - web_server.stop:
+            - lambda: 'id(roode_platform).stop_portal();'
 
 esp32:
   board: wemos_d1_mini32
@@ -44,6 +55,29 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
+
+globals:
+  - id: portal_on
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+switch:
+  - platform: template
+    id: portal_switch
+    name: Portal
+    lambda: |-
+      return id(portal_on);
+    turn_on_action:
+      - lambda: |-
+          id(portal_on) = true;
+          id(roode_platform).start_portal();
+      - web_server.start:
+    turn_off_action:
+      - lambda: |-
+          id(portal_on) = false;
+          id(roode_platform).stop_portal();
+      - web_server.stop:
 
 # Enable logging
 logger:

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -13,6 +13,17 @@ esphome:
   name: $devicename
   platform: ESP8266
   board: d1_mini
+  on_boot:
+    then:
+      - if:
+          condition:
+            lambda: 'return id(portal_on);'
+          then:
+            - lambda: 'id(roode_platform).start_portal();'
+            - web_server.start:
+          else:
+            - web_server.stop:
+            - lambda: 'id(roode_platform).stop_portal();'
 
 wifi:
   networks:
@@ -44,6 +55,29 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
+
+globals:
+  - id: portal_on
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+switch:
+  - platform: template
+    id: portal_switch
+    name: Portal
+    lambda: |-
+      return id(portal_on);
+    turn_on_action:
+      - lambda: |-
+          id(portal_on) = true;
+          id(roode_platform).start_portal();
+      - web_server.start:
+    turn_off_action:
+      - lambda: |-
+          id(portal_on) = false;
+          id(roode_platform).stop_portal();
+      - web_server.stop:
 
 # Enable logging
 logger:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -10,6 +10,17 @@ esphome:
   name: $devicename
   platform: ESP8266
   board: d1_mini
+  on_boot:
+    then:
+      - if:
+          condition:
+            lambda: 'return id(portal_on);'
+          then:
+            - lambda: 'id(roode_platform).start_portal();'
+            - web_server.start:
+          else:
+            - web_server.stop:
+            - lambda: 'id(roode_platform).stop_portal();'
 
 wifi:
   networks:
@@ -41,6 +52,29 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
+
+globals:
+  - id: portal_on
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+switch:
+  - platform: template
+    id: portal_switch
+    name: Portal
+    lambda: |-
+      return id(portal_on);
+    turn_on_action:
+      - lambda: |-
+          id(portal_on) = true;
+          id(roode_platform).start_portal();
+      - web_server.start:
+    turn_off_action:
+      - lambda: |-
+          id(portal_on) = false;
+          id(roode_platform).stop_portal();
+      - web_server.stop:
 
 # Enable logging
 logger:


### PR DESCRIPTION
## Summary
- add helper methods for enabling/disabling web portal and guard endpoint registration
- expose portal switch in example configs to start/stop the web server and persist state

## Testing
- `esphome config peopleCounter32.yaml` (fails: 'ota' requires a 'platform' key but it was not specified)
- `esphome config peopleCounter8266.yaml` (fails: remove the platform key from the [esphome] block)
- `platformio run -e roode` (fails: fatal error: esphome/components/binary_sensor/binary_sensor.h: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68ae70b033fc833080a2e81eda0e60fc