### PR TITLE
Document portal switch and REST API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A people counter that works with any smart home system that supports ESPHome/MQT
 - [Threshold distance](#threshold-distance)
 - [Algorithm](#algorithm)
 - [Features](#features)
+- [Web Portal & API](#web-portal--api)
 - [Logging and Diagnostics](#logging-and-diagnostics)
 - [Calibration Workflow](#calibration-workflow)
 - [FAQ/Troubleshoot](#faqtroubleshoot)
@@ -666,6 +667,33 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | Sensor status reporting | Text sensor shows `ok`, `timeout`, `reinitializing`, `error` or `offline` |
 | Event logging | Logs sensor power cycles, fallback reasons, and manual adjustments |
 | Colored logs | Normal info in green, details in yellow, failures in red |
+
+## Web Portal & API
+
+Roode includes a lightweight web portal for configuration and calibration.
+To conserve resources the web server is stopped on boot and only started
+when the `portal_switch` is turned on. The example YAML files define this
+template switch and tie it to `roode_platform.start_portal()`/`stop_portal()`
+along with the ESPHome `web_server.start`/`web_server.stop` actions.
+
+When enabled the portal responds on `/portal` (or `/`) and exposes several
+JSON endpoints:
+
+- `/api/settings/current` – current firmware and ROI settings.
+- `/api/scan/start` *(POST)* – begin a passive scan session.
+- `/api/scan/status` – progress of the active scan.
+- `/api/scan/cancel` *(POST)* – cancel the running scan.
+- `/api/roi/preview` – show recommended ROI/threshold values.
+- `/api/roi/apply` *(POST)* – apply the recommended values.
+- `/api/scan/sessions` – list recorded calibration sessions.
+- `/api/scan/session/<id>` – retrieve a specific session.
+- `/api/scan/delete` *(POST)* – remove stored sessions.
+- `/api/export/all` – export all session data as JSON.
+
+Leave the switch off during normal operation to keep memory and CPU usage
+low. If the ESPHome `api:` component is enabled, the `Portal` switch is
+also published as a Home Assistant entity for easy toggling from the UI or
+automations.
 
 ## Logging and Diagnostics
 

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -23,6 +23,65 @@ Roode now exposes button entities to start a passive scan or force a recalibrati
       newCount: "{{ states('input_number.set_people32') | int }}"
 ```
 
+## Portal Switch and REST API
+
+Roode ships with an optional web portal that serves a small HTML page and a
+REST API for configuration and calibration tasks. The web server is disabled
+on boot to save memory; enable it only when needed.
+
+### Enabling the portal
+
+The example firmware defines a `portal_switch` template switch. Turning this
+switch on starts the web server and registers the portal; turning it off stops
+both the server and the portal logic:
+
+```yaml
+globals:
+  - id: portal_on
+    type: bool
+    restore_value: yes
+    initial_value: 'false'
+
+switch:
+  - platform: template
+    id: portal_switch
+    name: Portal
+    lambda: |-
+      return id(portal_on);
+    turn_on_action:
+      - lambda: |-
+          id(portal_on) = true;
+          id(roode_platform).start_portal();
+      - web_server.start:
+    turn_off_action:
+      - lambda: |-
+          id(portal_on) = false;
+          id(roode_platform).stop_portal();
+      - web_server.stop:
+```
+
+If the ESPHome `api:` component is enabled, this `Portal` switch is exposed to
+Home Assistant and can be toggled from the UI or via automations.
+
+### Endpoints
+
+When the portal is active the device serves:
+
+- `/portal` or `/` – simple HTML configuration page.
+- `/api/settings/current` – current firmware and ROI settings.
+- `/api/scan/start` *(POST)* – start a passive scan.
+- `/api/scan/status` – progress of the active scan.
+- `/api/scan/cancel` *(POST)* – cancel the running scan.
+- `/api/roi/preview` – preview recommended ROI/threshold values.
+- `/api/roi/apply` *(POST)* – apply the recommended settings.
+- `/api/scan/sessions` – list stored calibration sessions.
+- `/api/scan/session/<id>` – retrieve a specific session.
+- `/api/scan/delete` *(POST)* – delete all stored sessions.
+- `/api/export/all` – export all session data as JSON.
+
+Leave the `portal_switch` off during normal operation to keep resource usage
+low. The portal and endpoints are only loaded while the switch is on.
+
 ## Passive Scan Trigger
 
 Roode exposes `Start Passive Scan` and `Recalibrate` button entities that


### PR DESCRIPTION
## Summary
- describe optional web portal and REST API
- explain enabling `portal_switch` and Home Assistant exposure
- note resource impact and list available endpoints

## Testing
- `npx markdownlint-cli README.md home_assistant.md` *(fails: line-length and formatting warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ae7be44bb08330b86e1b5c100aadf6