### PR TITLE
Add ArduinoJson dependency for roode component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.2
+- Add ArduinoJson dependency to resolve missing header during compile
+
 ## 1.6.1
 - Remove debug logging and cleanup unused code
 

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -158,6 +158,8 @@ CONFIG_SCHEMA = cv.Schema(
 
 
 async def to_code(config: Dict):
+    cg.add_library("bblanchon", "6.21.3", "ArduinoJson")
+
     roode = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(roode, config)
 


### PR DESCRIPTION
## Summary
- ensure the roode component installs the ArduinoJson library during build
- document the new ArduinoJson dependency in the changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae7f434f48833082ba6b5eb9771bf6