### PR TITLE
feat(web): refresh calibration portal UI

### DIFF
--- a/components/roode/web/portal.html
+++ b/components/roode/web/portal.html
@@ -1,147 +1,291 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Roode Portal</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Roode Calibration Portal</title>
   <style>
-    body { font-family: Arial, sans-serif; margin: 20px; }
-    button { margin: 4px; }
-    pre { background: #f0f0f0; padding: 10px; }
-    table { border-collapse: collapse; width: 100%; margin-top: 10px; }
-    th, td { border: 1px solid #ccc; padding: 4px; text-align: left; }
+    :root {
+      --bg:#0b0f14; --panel:#121821; --text:#e6edf3; --muted:#9fb0c3; --acc:#57a6ff;
+      --ok:#5bd19b; --warn:#ffcc66; --err:#ff6b6b; --line:#1f2835;
+    }
+    @media (prefers-color-scheme: light) {
+      :root {
+        --bg:#f6f8fa; --panel:#ffffff; --text:#24292f; --muted:#57606a; --acc:#0969da;
+        --ok:#1a7f37; --warn:#9a6700; --err:#cf222e; --line:#d0d7de;
+      }
+    }
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--text);font:14px/1.4 system-ui,-apple-system,Segoe UI,Roboto,Inter,sans-serif}
+    .wrap{max-width:1000px;margin:24px auto;padding:0 16px}
+    .hdr{display:flex;gap:16px;align-items:center;justify-content:space-between;margin-bottom:12px}
+    .hdr h1{font-size:18px;margin:0;font-weight:600}
+    .status{font-size:12px;color:var(--muted)}
+    .row{display:flex;gap:16px;flex-wrap:wrap}
+    .card{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:16px;flex:1 1 300px;min-width:300px}
+    .card h2{margin:0 0 10px 0;font-size:14px;font-weight:600;color:var(--acc)}
+    .btns{display:flex;gap:8px;flex-wrap:wrap}
+    button,.btn{appearance:none;border:1px solid var(--line);background:#0f1520;color:var(--text);padding:8px 12px;border-radius:10px;font-weight:600;cursor:pointer}
+    @media (prefers-color-scheme: light){ button,.btn{background:#f6f8fa;color:var(--text)} }
+    button:hover,.btn:hover{border-color:#39475e}
+    .btn.primary{background:var(--acc);color:#fff;border-color:#3e7cc8}
+    .btn.ghost{background:transparent}
+    .kv{display:grid;grid-template-columns:160px 1fr;gap:6px 12px}
+    .kv .k{color:var(--muted)}
+    .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:12px}
+    .progress{height:10px;border-radius:8px;background:#0f1520;border:1px solid var(--line);overflow:hidden}
+    @media (prefers-color-scheme: light){.progress{background:#e6edf3}}
+    .progress>div{height:100%;background:linear-gradient(90deg,#4cc2ff,#57a6ff);width:0%}
+    table{width:100%;border-collapse:collapse}
+    th,td{padding:8px 6px;border-bottom:1px solid var(--line);text-align:left}
+    th{color:var(--acc);font-weight:600}
+    .chips{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+    .right{margin-left:auto}
+    .hr{height:1px;background:var(--line);margin:12px 0}
+    .muted{color:var(--muted)}
   </style>
 </head>
 <body>
-  <h1>Roode Portal</h1>
-  <section id="controls">
-    <button id="startScan">Start Scan</button>
-    <button id="cancelScan">Cancel Scan</button>
-    <span id="scanStatus"></span>
-  </section>
+  <div class="wrap">
+    <div class="hdr">
+      <h1>Roode Calibration Portal</h1>
+      <div class="status"><span id="statusText">Status: <b>Idle</b></span> · <span id="lastCal">Last calibration: —</span></div>
+    </div>
 
-  <section id="current">
-    <h2>Current Settings</h2>
-    <pre id="currentSettings">{}</pre>
-    <button id="copyCurrent">Copy as JSON</button>
-  </section>
+    <!-- Controls & live status -->
+    <div class="row">
+      <div class="card" style="flex:1 1 100%">
+        <div class="btns">
+          <button class="btn primary" id="btnStart">Start Calibration</button>
+          <button class="btn" id="btnCancel" style="display:none">Cancel Scan</button>
+        </div>
+        <div class="hr"></div>
+        <div class="kv">
+          <div class="k">Active Session</div><div id="activeSession">—</div>
+          <div class="k">Step</div><div id="stepText">—</div>
+          <div class="k">Progress</div>
+          <div><div class="progress"><div id="progressBar" style="width:0%"></div></div></div>
+        </div>
+      </div>
 
-  <section id="recommended">
-    <h2>Recommended Settings</h2>
-    <pre id="recommendedSettings">{}</pre>
-    <button id="copyRecommended">Copy as JSON</button>
-    <button id="applySettings">Apply Settings</button>
-    <button id="saveRoi">Save roi_result.json</button>
-  </section>
+      <!-- Current Settings -->
+      <div class="card">
+        <h2>Current Settings</h2>
+        <div class="kv" id="currentSettings">
+          <div class="k">ROI Size</div><div id="curRoiSize">—</div>
+          <div class="k">ROI Center</div><div id="curRoiCenter">—</div>
+          <div class="k">Entry Center</div><div id="curEntry">—</div>
+          <div class="k">Exit Center</div><div id="curExit">—</div>
+          <div class="k">Ranging Mode</div><div id="curMode">—</div>
+          <div class="k">Min Threshold</div><div id="curMin">—</div>
+          <div class="k">Max Threshold</div><div id="curMax">—</div>
+          <div class="k">Sampling</div><div id="curSampling">—</div>
+          <div class="k">Firmware</div><div id="curFw">—</div>
+        </div>
+        <div class="chips">
+          <button class="btn" id="btnCopyJSON">Copy as JSON</button>
+        </div>
+      </div>
 
-  <section id="sessions">
-    <h2>Past Sessions</h2>
-    <button id="refreshSessions">Refresh</button>
-    <button id="exportSessions">Export All</button>
-    <button id="deleteSessions">Delete All</button>
-    <table id="sessionsTable">
-      <thead>
-        <tr><th>ID</th><th>Timestamp</th><th>Trials</th><th>Duration</th><th>Size</th><th>Actions</th></tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </section>
+      <!-- Recommended Settings -->
+      <div class="card" style="flex:1 1 380px">
+        <h2>Recommended Settings</h2>
+        <div class="kv" id="preview">
+          <div class="k">ROI Size</div><div id="pvRoiSize">—</div>
+          <div class="k">ROI Center</div><div id="pvRoi">—</div>
+          <div class="k">Entry Center</div><div id="pvEntry">—</div>
+          <div class="k">Exit Center</div><div id="pvExit">—</div>
+          <div class="k">Ranging Mode</div><div id="pvMode">—</div>
+          <div class="k">Min Threshold</div><div id="pvMin">—</div>
+          <div class="k">Max Threshold</div><div id="pvMax">—</div>
+          <div class="k">Sampling</div><div id="pvSampling">—</div>
+          <div class="k">Firmware</div><div id="pvFw">—</div>
+        </div>
+        <div class="chips">
+          <button class="btn" id="btnApply">Apply Settings</button>
+          <a class="btn" id="dlResult" href="#" download>Save roi_result.json</a>
+        </div>
+      </div>
 
-<script>
-async function fetchJSON(url, opts) {
-  const res = await fetch(url, opts);
-  return await res.json();
-}
+      <!-- Past Sessions -->
+      <div class="card" style="flex:1 1 100%">
+        <div style="display:flex;align-items:center;justify-content:space-between">
+          <h2>Past Sessions</h2>
+          <a class="btn ghost" id="btnExport" href="/api/export/all">Export All ▾</a>
+        </div>
+        <div style="overflow:auto">
+          <table id="tblSessions">
+            <thead>
+              <tr>
+                <th>#</th><th>Date/Time</th><th>Session ID</th><th>Trials</th>
+                <th>Duration</th><th>Size</th><th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- Placeholder row (will be replaced by JS when data is available) -->
+              <tr>
+                <td>1</td><td>2025-08-26 17:00</td><td>calibration_2025-08-26_1700</td>
+                <td>3</td><td>02:15</td><td>24.1KB</td>
+                <td class="mono">
+                  <a href="/api/scan/session/calibration_2025-08-26_1700">Download</a>
+                  &nbsp;|&nbsp;<a href="#" data-view="calibration_2025-08-26_1700">View</a>
+                  &nbsp;|&nbsp;<a href="#" data-del="calibration_2025-08-26_1700">Delete</a>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
 
-async function updateCurrent() {
-  const data = await fetchJSON('/api/settings/current');
-  document.getElementById('currentSettings').textContent = JSON.stringify(data, null, 2);
-}
+    </div><!-- /row -->
+  </div><!-- /wrap -->
 
-async function updateRecommended() {
-  const data = await fetchJSON('/api/roi/preview');
-  document.getElementById('recommendedSettings').textContent = JSON.stringify(data, null, 2);
-}
+  <script>
+  // Helpers
+  const $ = (s)=>document.querySelector(s);
+  const fmtBytes = n => {
+    if(n==null) return '—';
+    const u=['B','KB','MB']; let i=0, v=n;
+    while(v>=1024 && i<u.length-1){ v/=1024; i++; }
+    return (i?v.toFixed(1):v|0) + ' ' + u[i];
+  };
+  const fmtDur = s => {
+    if(!Number.isFinite(s)) return '—';
+    const m = Math.floor(s/60), sec = s%60;
+    return String(m).padStart(2,'0')+':'+String(sec).padStart(2,'0');
+  };
 
-async function startScan() {
-  await fetchJSON('/api/scan/start', {method:'POST'});
-  pollStatus();
-}
+  // State
+  let current = null, preview = null, status = null, sessions = [];
 
-async function cancelScan() {
-  await fetchJSON('/api/scan/cancel', {method:'POST'});
-}
-
-async function pollStatus() {
-  const status = await fetchJSON('/api/scan/status');
-  const text = status.running ? `Running ${status.step} ${status.progress}%` : 'Idle';
-  document.getElementById('scanStatus').textContent = text;
-  if (status.running) {
-    setTimeout(pollStatus, 1000);
-  } else {
-    updateRecommended();
-    updateSessions();
+  // Fetch JSON with graceful fallback
+  async function getJSON(url){
+    try { const r = await fetch(url, {cache:'no-store'}); if(!r.ok) throw 0; return await r.json(); }
+    catch { return null; }
   }
-}
-
-function copyText(id) {
-  const text = document.getElementById(id).textContent;
-  navigator.clipboard.writeText(text);
-}
-
-function saveFile(name, text) {
-  const blob = new Blob([text], {type:'application/json'});
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = name;
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
-
-async function applySettings() {
-  const r = await fetchJSON('/api/roi/apply', {method:'POST'});
-  if (r.applied) updateCurrent();
-}
-
-async function updateSessions() {
-  const data = await fetchJSON('/api/scan/sessions');
-  const tbody = document.querySelector('#sessionsTable tbody');
-  tbody.innerHTML = '';
-  for (const s of data.sessions) {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td>${s.id}</td><td>${s.timestamp}</td><td>${s.trials}</td><td>${s.duration}</td><td>${s.size}</td><td><button class="download" data-id="${s.id}">Download</button></td>`;
-    tbody.appendChild(tr);
+  async function postJSON(url, body){
+    try { const r = await fetch(url, {method:'POST', headers:{'Content-Type':'application/json'}, body: body?JSON.stringify(body):'{}'}); if(!r.ok) throw 0; return await r.json().catch(()=>({ok:true})); }
+    catch { return { ok:false }; }
   }
-}
-</script>
 
-<script>
-document.getElementById('startScan').addEventListener('click', startScan);
-document.getElementById('cancelScan').addEventListener('click', cancelScan);
-document.getElementById('copyCurrent').addEventListener('click', () => copyText('currentSettings'));
-document.getElementById('copyRecommended').addEventListener('click', () => copyText('recommendedSettings'));
-document.getElementById('applySettings').addEventListener('click', applySettings);
-document.getElementById('saveRoi').addEventListener('click', () => saveFile('roi_result.json', document.getElementById('recommendedSettings').textContent));
-document.getElementById('refreshSessions').addEventListener('click', updateSessions);
-document.getElementById('exportSessions').addEventListener('click', async () => {
-  const data = await fetchJSON('/api/export/all');
-  saveFile('sessions.json', JSON.stringify(data, null, 2));
-});
-document.getElementById('deleteSessions').addEventListener('click', async () => {
-  await fetchJSON('/api/scan/delete', {method:'POST'});
-  updateSessions();
-});
-document.querySelector('#sessionsTable').addEventListener('click', async (e) => {
-  if (e.target.classList.contains('download')) {
-    const id = e.target.getAttribute('data-id');
-    const data = await fetchJSON(`/api/scan/session/${id}`);
-    saveFile(`session_${id}.json`, JSON.stringify(data, null, 2));
+  // Renderers
+  function renderStatus(){
+    const st = status || {state:'Idle', id:'—', step:'—', progress:0};
+    $('#statusText').innerHTML = 'Status: <b>'+st.state+'</b>';
+    $('#activeSession').textContent = st.id || '—';
+    $('#stepText').textContent = st.step || '—';
+    $('#progressBar').style.width = (st.progress||0)+'%';
+    $('#btnCancel').style.display = (st.state==='Scanning') ? 'inline-block' : 'none';
   }
-});
+  function renderCurrent(){
+    if(!current) return;
+    $('#curRoiSize').textContent = (current.roi_width&&current.roi_height) ? `${current.roi_width} × ${current.roi_height}` : '—';
+    $('#curRoiCenter').textContent = current.roi_center ? `(${current.roi_center.x}, ${current.roi_center.y})` : '—';
+    $('#curEntry').textContent = current.entry_center ? `(${current.entry_center.x}, ${current.entry_center.y})` : '—';
+    $('#curExit').textContent = current.exit_center ? `(${current.exit_center.x}, ${current.exit_center.y})` : '—';
+    $('#curMode').textContent = current.ranging_mode || '—';
+    $('#curMin').textContent = current.min_threshold!=null ? current.min_threshold+'%' : '—';
+    $('#curMax').textContent = current.max_threshold!=null ? current.max_threshold+'%' : '—';
+    $('#curSampling').textContent = current.sampling || '—';
+    $('#curFw').textContent = current.firmware || '—';
+    if(current.last_calibration) $('#lastCal').textContent = 'Last calibration: ' + new Date(current.last_calibration).toLocaleString();
+  }
+  function renderPreview(){
+    if(!preview){ // clear
+      $('#pvRoiSize').textContent = '—'; $('#pvRoi').textContent='—';
+      $('#pvEntry').textContent='—'; $('#pvExit').textContent='—';
+      $('#pvMode').textContent='—'; $('#pvMin').textContent='—';
+      $('#pvMax').textContent='—'; $('#pvSampling').textContent='—'; $('#pvFw').textContent='—';
+      $('#dlResult').removeAttribute('href');
+      return;
+    }
+    const r = preview;
+    if(r.roi){ $('#pvRoiSize').textContent = `${r.roi.width} × ${r.roi.height}`; $('#pvRoi').textContent = `(${r.roi.center.x}, ${r.roi.center.y})`; }
+    if(r.zones){ $('#pvEntry').textContent = `(${r.zones.entry.x}, ${r.zones.entry.y})`; $('#pvExit').textContent = `(${r.zones.exit.x}, ${r.zones.exit.y})`; }
+    $('#pvMode').textContent = r.ranging_mode || '—';
+    if(r.thresholds){ $('#pvMin').textContent = r.thresholds.min+'%'; $('#pvMax').textContent = r.thresholds.max+'%'; }
+    $('#pvSampling').textContent = r.sampling || '—';
+    $('#pvFw').textContent = r.firmware || '—';
+    if(r.download) $('#dlResult').href = r.download;
+  }
+  function renderSessions(){
+    const tbody = document.querySelector('#tblSessions tbody');
+    tbody.innerHTML = '';
+    if(!sessions || !sessions.length){
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td colspan="7" class="muted">No sessions yet.</td>';
+      tbody.appendChild(tr);
+      return;
+    }
+    sessions.sort((a,b)=>new Date(b.ts)-new Date(a.ts)).forEach((s, i)=>{
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${i+1}</td>
+        <td>${new Date(s.ts).toLocaleString()}</td>
+        <td class="mono">${s.id}</td>
+        <td>${s.trials ?? '—'}</td>
+        <td>${fmtDur(s.duration_sec)}</td>
+        <td>${fmtBytes(s.size_bytes)}</td>
+        <td class="mono">
+          <a href="/api/scan/session/${encodeURIComponent(s.id)}">Download</a>
+          &nbsp;|&nbsp;<a href="#" data-view="${s.id}">View</a>
+          &nbsp;|&nbsp;<a href="#" data-del="${s.id}">Delete</a>
+        </td>`;
+      tbody.appendChild(tr);
+    });
+  }
 
-updateCurrent();
-updateRecommended();
-updateSessions();
-pollStatus();
-</script>
+  // Polling
+  async function poll(){
+    const [cur, stat, list, prev] = await Promise.all([
+      getJSON('/api/settings/current'),
+      getJSON('/api/scan/status'),
+      getJSON('/api/scan/sessions'),
+      getJSON('/api/roi/preview')
+    ]);
+    if(cur) current = cur;
+    if(stat) status = stat;
+    if(list) sessions = list;
+    // Only show preview if we have one (typically after completion)
+    preview = prev || null;
+
+    renderStatus(); renderCurrent(); renderPreview(); renderSessions();
+  }
+
+  // Actions
+  $('#btnStart').addEventListener('click', async ()=>{
+    const r = await postJSON('/api/scan/start');
+    if(r && r.id){ status = {state:'Scanning', id:r.id, step:'8×8 Scan', progress:0}; renderStatus(); }
+  });
+  $('#btnCancel').addEventListener('click', async ()=>{
+    await postJSON('/api/scan/cancel'); status = {state:'Idle', id:status?.id || '—', step:'—', progress:0}; renderStatus();
+  });
+  $('#btnApply').addEventListener('click', async ()=>{
+    const r = await postJSON('/api/roi/apply');
+    if(r && r.ok) { /* next poll will refresh Current Settings */ }
+  });
+  $('#btnCopyJSON').addEventListener('click', ()=>{
+    if(!current) return;
+    navigator.clipboard.writeText(JSON.stringify(current, null, 2));
+  });
+  document.querySelector('#tblSessions').addEventListener('click', async (e)=>{
+    const a = e.target.closest('a'); if(!a) return;
+    if(a.dataset.view){ e.preventDefault();
+      // Prefer a queryable preview endpoint per session if available:
+      const prev = await getJSON(`/api/roi/preview?session_id=${encodeURIComponent(a.dataset.view)}`);
+      preview = prev || preview; renderPreview();
+      document.querySelector('#preview')?.scrollIntoView({behavior:'smooth', block:'start'});
+    }
+    if(a.dataset.del){ e.preventDefault();
+      await postJSON('/api/scan/delete', { session_id: a.dataset.del });
+      sessions = (sessions||[]).filter(s => s.id !== a.dataset.del);
+      renderSessions();
+    }
+  });
+
+  // Kick off
+  poll();
+  setInterval(poll, 1500);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- overhaul calibration portal with new dark/light theme design
- show live status, recommended settings, and session history in responsive cards

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ae858ccb0c8330948d42cb7aea0253