### PR TITLE
Handle web server start-stop internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,12 +173,10 @@ switch:
       - lambda: |-
           id(portal_on) = true;
           id(roode_platform).start_portal();
-      - web_server.start:
     turn_off_action:
       - lambda: |-
           id(portal_on) = false;
           id(roode_platform).stop_portal();
-      - web_server.stop:
 
 # Convenience restart button
 button:
@@ -710,8 +708,8 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 Roode includes a lightweight web portal for configuration and calibration.
 To conserve resources the web server is stopped on boot and only started
 when the `portal_switch` is turned on. The example YAML files define this
-template switch and tie it to `roode_platform.start_portal()`/`stop_portal()`
-along with the ESPHome `web_server.start`/`web_server.stop` actions.
+template switch and tie it to `roode_platform.start_portal()`/`stop_portal()`,
+which handle starting and stopping the ESPHome web server internally.
 
 When enabled the portal responds on `/portal` (or `/`) and exposes several
 JSON endpoints:

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -156,12 +156,9 @@ void Roode::register_server_endpoints() {
   auto server = web_server_base::global_web_server_base->get_server();
   portal_registered_ = true;
 
-  server->on("/portal", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send_P(200, "text/html", portal_html);
-  });
-  server->on("/", HTTP_GET, [](AsyncWebServerRequest *request) {
-    request->send_P(200, "text/html", portal_html);
-  });
+  server->on("/portal", HTTP_GET,
+             [](AsyncWebServerRequest *request) { request->send_P(200, "text/html", portal_html); });
+  server->on("/", HTTP_GET, [](AsyncWebServerRequest *request) { request->send_P(200, "text/html", portal_html); });
 
   server->on("/api/settings/current", HTTP_GET, [this](AsyncWebServerRequest *request) {
     DynamicJsonDocument doc(512);
@@ -389,11 +386,22 @@ void Roode::register_server_endpoints() {
 void Roode::start_portal() {
   portal_enabled_ = true;
 #ifdef USE_WEB_SERVER
-  register_server_endpoints();
+  if (web_server_base::global_web_server_base != nullptr) {
+    web_server_base::global_web_server_base->init();
+    register_server_endpoints();
+  }
 #endif
 }
 
-void Roode::stop_portal() { portal_enabled_ = false; }
+void Roode::stop_portal() {
+  portal_enabled_ = false;
+#ifdef USE_WEB_SERVER
+  if (web_server_base::global_web_server_base != nullptr) {
+    web_server_base::global_web_server_base->deinit();
+  }
+  portal_registered_ = false;
+#endif
+}
 
 void Roode::set_auto_calibration_interval_sec(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
 void Roode::dump_config() {
@@ -423,7 +431,8 @@ void Roode::setup() {
   this->register_service(&Roode::start_passive_scan, "start_passive_scan");
 #endif
 #ifdef USE_WEB_SERVER
-  if (portal_enabled_) {
+  if (portal_enabled_ && web_server_base::global_web_server_base != nullptr) {
+    web_server_base::global_web_server_base->init();
     register_server_endpoints();
   }
 #endif
@@ -1115,12 +1124,12 @@ void Roode::start_passive_scan() {
       distanceSensor->set_ranging_mode(ranging_mode);
 
       std::vector<float> cv_trials;
-        for (int trial = 1; trial <= max_trials; ++trial) {
-          if (scan_cancel_requested) {
-            publish_scan_record("scan_cancel");
-            scan_running = false;
-            return;
-          }
+      for (int trial = 1; trial <= max_trials; ++trial) {
+        if (scan_cancel_requested) {
+          publish_scan_record("scan_cancel");
+          scan_running = false;
+          return;
+        }
         std::vector<int> mcps(grid * grid, 0);
         std::vector<int> distance(grid * grid, 0);
         std::vector<float> snr(grid * grid, 0.0f);
@@ -1232,14 +1241,9 @@ void Roode::start_passive_scan() {
   float elapsed = (millis() - scan_start_ts_) / 1000.0f;
   if (scan_time_cap_seconds_sensor != nullptr)
     scan_time_cap_seconds_sensor->publish_state(elapsed);
-  recommended_settings_ = RecommendedSettings{*entry->roi,
-                                             *exit->roi,
-                                             entry->threshold->min,
-                                             entry->threshold->max,
-                                             exit->threshold->min,
-                                             exit->threshold->max,
-                                             samples,
-                                             VERSION};
+  recommended_settings_ = RecommendedSettings{
+      *entry->roi, *exit->roi, entry->threshold->min, entry->threshold->max, exit->threshold->min, exit->threshold->max,
+      samples,     VERSION};
   scan_progress_ = 1.0f;
   save_current_scan_session();
   scan_running = false;

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -52,12 +52,10 @@ switch:
       - lambda: |-
           id(portal_on) = true;
           id(roode_platform).start_portal();
-      - web_server.start:
     turn_off_action:
       - lambda: |-
           id(portal_on) = false;
           id(roode_platform).stop_portal();
-      - web_server.stop:
 ```
 
 If the ESPHome `api:` component is enabled, this `Portal` switch is exposed to

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -18,9 +18,7 @@ esphome:
             lambda: 'return id(portal_on);'
           then:
             - lambda: 'id(roode_platform).start_portal();'
-            - web_server.start:
           else:
-            - web_server.stop:
             - lambda: 'id(roode_platform).stop_portal();'
 
 esp32:
@@ -75,12 +73,10 @@ switch:
       - lambda: |-
           id(portal_on) = true;
           id(roode_platform).start_portal();
-      - web_server.start:
     turn_off_action:
       - lambda: |-
           id(portal_on) = false;
           id(roode_platform).stop_portal();
-      - web_server.stop:
 
 # Enable logging
 logger:

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -15,9 +15,7 @@ esphome:
             lambda: 'return id(portal_on);'
           then:
             - lambda: 'id(roode_platform).start_portal();'
-            - web_server.start:
           else:
-            - web_server.stop:
             - lambda: 'id(roode_platform).stop_portal();'
 
 esp32:
@@ -72,12 +70,10 @@ switch:
       - lambda: |-
           id(portal_on) = true;
           id(roode_platform).start_portal();
-      - web_server.start:
     turn_off_action:
       - lambda: |-
           id(portal_on) = false;
           id(roode_platform).stop_portal();
-      - web_server.stop:
 
 # Enable logging
 logger:

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -20,9 +20,7 @@ esphome:
             lambda: 'return id(portal_on);'
           then:
             - lambda: 'id(roode_platform).start_portal();'
-            - web_server.start:
           else:
-            - web_server.stop:
             - lambda: 'id(roode_platform).stop_portal();'
 
 wifi:
@@ -72,12 +70,10 @@ switch:
       - lambda: |-
           id(portal_on) = true;
           id(roode_platform).start_portal();
-      - web_server.start:
     turn_off_action:
       - lambda: |-
           id(portal_on) = false;
           id(roode_platform).stop_portal();
-      - web_server.stop:
 
 # Enable logging
 logger:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -17,9 +17,7 @@ esphome:
             lambda: 'return id(portal_on);'
           then:
             - lambda: 'id(roode_platform).start_portal();'
-            - web_server.start:
           else:
-            - web_server.stop:
             - lambda: 'id(roode_platform).stop_portal();'
 
 wifi:
@@ -69,12 +67,10 @@ switch:
       - lambda: |-
           id(portal_on) = true;
           id(roode_platform).start_portal();
-      - web_server.start:
     turn_off_action:
       - lambda: |-
           id(portal_on) = false;
           id(roode_platform).stop_portal();
-      - web_server.stop:
 
 # Enable logging
 logger:


### PR DESCRIPTION
## Summary
- manage ESPHome web server lifecycle inside `roode_platform` portal helpers
- drop deprecated `web_server.start/stop` actions from examples and docs

## Testing
- `esphome config peopleCounter32.yaml` *(fails: 'ota' requires a 'platform' key)*
- `yamllint peopleCounter32.yaml` *(fails: style issues and line length)*

------
https://chatgpt.com/codex/tasks/task_e_68ae8710364083308f337bd48033a605