### PR TITLE
Add configurable auto calibration interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ roode:
   # Increase to 4-5 if jitter is a problem; 1 is fastest but noisier
   sampling: 2
 
+  # Time between automatic recalibration runs
+  auto_calibration_interval: 4h
+
   # The orientation of the two sensor pads in relation to the entryway being tracked.
   # The advised orientation is parallel, but if needed this can be changed to perpendicular.
   orientation: parallel
@@ -333,6 +336,7 @@ reflections cause false triggers.
 | `roode.force_single_core` | Optional | `false` | Disable dual-core optimization | ESP32 issues with multi-core | Set true if crashes occur | `force_single_core: false` | `force_single_core: true` |
 | `roode.invalid_distance_limit` | Optional | `10` | Consecutive suspect readings before restart | Sporadic zero/4 m values | Increase if noise triggers resets | `invalid_distance_limit: 10` | `invalid_distance_limit: 20` |
 | `roode.restart_timeout` | Optional | `30s` | Cooldown and timeout before restart | Slow updates or many resets | Shorten for faster recovery | `restart_timeout: 30s` | `restart_timeout: 15s` |
+| `roode.auto_calibration_interval` | Optional | `4h` | Interval between automatic recalibrations | Environment drift | Adjust or disable frequent recalibration | `auto_calibration_interval: 4h` | `auto_calibration_interval: 2h` |
 | `roode.cpu_optimization.activate` & `roode.cpu_optimization.deactivate` | Optional | `90%` / `50%` | CPU usage thresholds for enabling or disabling reduced filtering | High MCU load or disable with 100% | Raise `activate` or set to `100%` to turn off | `cpu_optimization: { activate: 90%, deactivate: 50% }` | `cpu_optimization: { activate: 95%, deactivate: 60% }` |
 | `roode.zones.invert` | Optional | `false` | Swap entry and exit zones | Counts appear reversed | Set true then recalibrate | `zones: { invert: false }` | `zones: { invert: true }` |
 | `roode.zones.entry/exit` | Optional | none | Per-zone ROI and thresholds | Uneven hallway or obstacles | Tweak each zone separately as needed | *(not set)* | `zones:`<br>`  exit:`<br>`    roi:`<br>`      height: 8` |
@@ -602,6 +606,7 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | Built-in pull-ups | XSHUT and interrupt pins use internal pull-ups, no resistors needed |
 | Metrics sensors | Optional sensors report loop time, CPU usage, RAM and flash usage |
 | Fail-safe recalibration | Triggers recalibration if a zone stays active too long |
+| Automatic periodic recalibration | Recalibrates after configurable interval |
 | Persistent calibration | Calibration data can persist in flash across reboots |
 | Dual-core tasking | Keeps polling responsive on ESP32 with automatic retry/fallback |
 | Filtering options | Median/percentile filters smooth jitter with adjustable window |

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -38,6 +38,7 @@ CONF_FORCE_SINGLE_CORE = "force_single_core"
 CONF_INVALID_DISTANCE_LIMIT = "invalid_distance_limit"
 CONF_RESTART_TIMEOUT = "restart_timeout"
 CONF_CPU_OPTIMIZATION = "cpu_optimization"
+CONF_AUTO_CALIBRATION_INTERVAL = "auto_calibration_interval"
 CONF_ACTIVATE = "activate"
 CONF_DEACTIVATE = "deactivate"
 
@@ -98,6 +99,9 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_FORCE_SINGLE_CORE, default=False): cv.boolean,
         cv.Optional(CONF_INVALID_DISTANCE_LIMIT, default=10): cv.All(cv.uint8_t, cv.Range(min=1)),
         cv.Optional(CONF_RESTART_TIMEOUT, default="30s"): cv.positive_time_period_milliseconds,
+        cv.Optional(
+            CONF_AUTO_CALIBRATION_INTERVAL, default="4h"
+        ): cv.positive_time_period_seconds,
         cv.Optional(CONF_CPU_OPTIMIZATION, default={}): cv.Schema(
             {
                 cv.Optional(CONF_ACTIVATE, default=0.90): cv.percentage,
@@ -131,6 +135,11 @@ async def to_code(config: Dict):
     cg.add(roode.set_force_single_core(config[CONF_FORCE_SINGLE_CORE]))
     cg.add(roode.set_invalid_distance_limit(config[CONF_INVALID_DISTANCE_LIMIT]))
     cg.add(roode.set_restart_timeout(config[CONF_RESTART_TIMEOUT]))
+    cg.add(
+        roode.set_auto_calibration_interval(
+            config[CONF_AUTO_CALIBRATION_INTERVAL]
+        )
+    )
     cpu_conf = config.get(CONF_CPU_OPTIMIZATION, {})
     cg.add(
         roode.set_cpu_optimization_thresholds(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -112,6 +112,8 @@ void Roode::log_event(const std::string &msg) {
   }
 }
 
+void Roode::set_auto_calibration_interval(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
+
 Roode::~Roode() {
   delete entry;
   delete exit;
@@ -185,8 +187,7 @@ void Roode::setup() {
   } else {
     calibrate_zones();
   }
-  last_calibration_ts_ =
-      std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
+  last_calibration_ts_ = std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
 #ifdef CONFIG_IDF_TARGET_ESP32
   if (!force_single_core_) {
     log_event("use_dual_core");
@@ -300,8 +301,7 @@ void Roode::loop() {
   } else {
     invalid_read_count_ = 0;
   }
-  if (invalid_read_count_ > invalid_distance_limit_ &&
-      (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
+  if (invalid_read_count_ > invalid_distance_limit_ && (now - last_sensor_restart_ts_ > restart_timeout_ms_)) {
     ESP_LOGW(TAG, "Consecutive invalid distances, restarting...");
     restart_sensor();
   }
@@ -320,8 +320,7 @@ void Roode::loop() {
   loop_count_++;
   update_metrics();
   uint32_t now_epoch = static_cast<uint32_t>(time(nullptr));
-  if (auto_calibration_interval_sec_ > 0 &&
-      now_epoch - last_calibration_ts_ >= auto_calibration_interval_sec_) {
+  if (auto_calibration_interval_sec_ > 0 && now_epoch - last_calibration_ts_ >= auto_calibration_interval_sec_) {
     run_zone_calibration(0);
     run_zone_calibration(1);
   }
@@ -534,8 +533,7 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   // thresholds and ROI values immediately after a fail-safe recalibration
   publish_sensor_configuration(entry, exit, true);
   publish_sensor_configuration(entry, exit, false);
-  last_calibration_ts_ =
-      std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
+  last_calibration_ts_ = std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
   publish_feature_list();
 }
 
@@ -659,8 +657,7 @@ void Roode::calibrate_zones() {
     calibration_prefs_[1].save(&calibration_data_[1]);
   }
   ESP_LOGI(SETUP, "Finished calibrating sensor zones");
-  last_calibration_ts_ =
-      std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
+  last_calibration_ts_ = std::max(calibration_data_[0].last_calibrated_ts, calibration_data_[1].last_calibrated_ts);
   publish_feature_list();
 }
 
@@ -769,7 +766,6 @@ void Roode::publish_feature_list() {
   log_event(std::string("features_enabled: ") + feature_list);
 }
 
-
 void Roode::update_status_text(const std::string &status) {
   if (status_text_sensor != nullptr && status != last_status_text_) {
     status_text_sensor->publish_state(status);
@@ -799,8 +795,7 @@ void Roode::sensor_task(void *param) {
   for (;;) {
     self->use_sensor_task_ = true;
     uint32_t now = millis();
-    if (self->last_loop_update_ts_ != 0 &&
-        (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
+    if (self->last_loop_update_ts_ != 0 && (now - self->last_loop_update_ts_ > self->restart_timeout_ms_) &&
         (now - self->last_sensor_restart_ts_ > self->restart_timeout_ms_)) {
       ESP_LOGW(TAG, "Sensor unresponsive >%ds, restarting...", self->restart_timeout_ms_ / 1000);
       self->restart_sensor();

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -129,6 +129,7 @@ class Roode : public PollingComponent {
   }
   void set_invalid_distance_limit(uint8_t limit) { invalid_distance_limit_ = limit; }
   void set_restart_timeout(uint32_t ms) { restart_timeout_ms_ = ms; }
+  void set_auto_calibration_interval(uint32_t sec);
   void set_cpu_optimization_thresholds(float activate, float deactivate) {
     cpu_opt_activate_threshold_ = activate;
     cpu_opt_deactivate_threshold_ = deactivate;

--- a/extra_sensors_example.yaml
+++ b/extra_sensors_example.yaml
@@ -7,6 +7,7 @@ vl53l1x:
 
 roode:
   sampling: 2
+  auto_calibration_interval: 4h
 
 sensor:
   - platform: roode

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -74,6 +74,7 @@ roode:
   id: roode_platform
   # Smooth out measurements by using the minimum distance from this number of readings
   sampling: 2
+  auto_calibration_interval: 4h
   # This controls the size of the Region of Interest the sensor should take readings in.
   roi: { height: 16, width: 6 }
   # The detection thresholds for determining whether a measurement should count as a person crossing.

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -71,6 +71,7 @@ roode:
   # I removed the { size: 1 } option here since it was redundant.
   # Can always add back later if we have more sampling paramaters.
   sampling: 2
+  auto_calibration_interval: 4h
   # defaults for both zones
   roi:
     # height: 14

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -71,6 +71,7 @@ roode:
   id: roode_platform
   # Smooth out measurements by using the minimum distance from this number of readings
   sampling: 2
+  auto_calibration_interval: 4h
   # This controls the size of the Region of Interest the sensor should take readings in.
   roi: { height: 16, width: 6 }
   # The detection thresholds for determining whether a measurement should count as a person crossing.

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -67,6 +67,7 @@ roode:
   # I removed the { size: 1 } option here since it was redundant.
   # Can always add back later if we have more sampling paramaters.
   sampling: 1
+  auto_calibration_interval: 4h
   # defaults for both zones
   roi:
     # height: 14


### PR DESCRIPTION
## Summary
- add `auto_calibration_interval` option and wire through to C++
- expose `set_auto_calibration_interval` and store interval on the device
- document automatic recalibration and update example configs

## Testing
- `python -m py_compile components/roode/__init__.py`
- `platformio run` *(fails: esphome components headers not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ae8e087f808330b24663b881928a8d