### PR TITLE
feat: add portal auth token

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -61,6 +61,7 @@ CONF_DEACTIVATE = "deactivate"
 CONF_TRIAL_BUMP_CV = "trial_bump_cv"
 CONF_SCAN_TIME_CAP_SECONDS = "scan_time_cap_seconds"
 CONF_ROI_RESULT = "roi_result"
+CONF_PORTAL_PASSWORD = "portal_password"
 
 FilterMode = roode_ns.enum("FilterMode")
 FILTER_MODES = {
@@ -141,10 +142,7 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=90.0): cv.All(
             cv.positive_float, cv.Range(min=60.0, max=180.0)
         ),
-
-      
-      
-      
+        cv.Optional(CONF_PORTAL_PASSWORD, default=""): cv.string,
         cv.Optional(CONF_ROI_RESULT): cv.file_,
         cv.Optional(CONF_ZONES, default={}): NullableSchema(
             {
@@ -208,6 +206,7 @@ async def to_code(config: Dict):
 
     cg.add(roode.set_orientation(config[CONF_ORIENTATION]))
     cg.add(roode.set_sampling_size(config[CONF_SAMPLING]))
+    cg.add(roode.set_portal_password(config[CONF_PORTAL_PASSWORD]))
     auto_conf = config.get(CONF_AUTO_CALIBRATION, {})
     cg.add(roode.set_calibration_persistence(auto_conf.get(CONF_PERSIST, False)))
     cg.add(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -151,6 +151,24 @@ Roode::~Roode() {
   delete exit;
 }
 
+bool Roode::check_token_(AsyncWebServerRequest *request) {
+#ifdef USE_WEB_SERVER
+  if (portal_password_.empty())
+    return true;
+  if (request->hasHeader("X-Portal-Token") && request->header("X-Portal-Token") == portal_password_.c_str())
+    return true;
+  if (request->hasParam("token")) {
+    auto param = request->getParam("token");
+    if (param->value() == portal_password_.c_str())
+      return true;
+  }
+  request->send(401, "text/plain", "Unauthorized");
+  return false;
+#else
+  return true;
+#endif
+}
+
 void Roode::register_server_endpoints() {
 #ifdef USE_WEB_SERVER
   if (portal_registered_ || web_server_base::global_web_server_base == nullptr)
@@ -158,11 +176,20 @@ void Roode::register_server_endpoints() {
   auto server = web_server_base::global_web_server_base->get_server();
   portal_registered_ = true;
 
-  server->on("/portal", HTTP_GET,
-             [](AsyncWebServerRequest *request) { request->send_P(200, "text/html", portal_html); });
-  server->on("/", HTTP_GET, [](AsyncWebServerRequest *request) { request->send_P(200, "text/html", portal_html); });
+  server->on("/portal", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
+    request->send_P(200, "text/html", portal_html);
+  });
+  server->on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
+    request->send_P(200, "text/html", portal_html);
+  });
 
   server->on("/api/settings/current", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     DynamicJsonDocument doc(512);
     doc["samples"] = samples;
     doc["filter_window"] = filter_window_;
@@ -195,6 +222,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/scan/status", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     DynamicJsonDocument doc(256);
     doc["running"] = scan_running;
     doc["session_id"] = scan_session_id_.c_str();
@@ -207,6 +236,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/scan/start", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     DynamicJsonDocument doc(128);
     if (!scan_running) {
       scan_cancel_requested = false;
@@ -226,6 +257,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/scan/cancel", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     scan_cancel_requested = true;
     DynamicJsonDocument doc(128);
     doc["cancelled"] = true;
@@ -236,6 +269,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/roi/preview", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     DynamicJsonDocument doc(512);
     if (recommended_settings_.has_value()) {
       JsonObject entry_cfg = doc.createNestedObject("entry");
@@ -286,6 +321,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/roi/apply", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     bool ok = this->apply_recommended_settings();
     DynamicJsonDocument doc(128);
     doc["ok"] = ok;
@@ -297,6 +334,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/scan/sessions", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     size_t doc_size = sessions_.size() * 128 + 128;
     DynamicJsonDocument doc(doc_size);
     JsonArray arr = doc.createNestedArray("sessions");
@@ -314,6 +353,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on(UriRegex("^/api/scan/session/(.+)$"), HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     uint32_t id = strtoul(request->pathArg(0).c_str(), nullptr, 10);
     const ScanSession *found = nullptr;
     for (const auto &s : sessions_) {
@@ -340,6 +381,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/scan/delete", HTTP_POST, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     for (int i = 0; i < MAX_SCAN_SESSIONS; i++)
       session_prefs_[i].erase();
     sessions_.clear();
@@ -353,6 +396,8 @@ void Roode::register_server_endpoints() {
   });
 
   server->on("/api/export/all", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
     size_t doc_size = sessions_.size() * (MAX_SESSION_DATA + 128) + 128;
     DynamicJsonDocument doc(doc_size);
     JsonArray arr = doc.createNestedArray("sessions");

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -17,6 +17,10 @@
 #include "orientation.h"
 #include "zone.h"
 
+#ifdef USE_WEB_SERVER
+class AsyncWebServerRequest;
+#endif
+
 using namespace esphome::vl53l1x;
 using TofSensor = esphome::vl53l1x::VL53L1X;
 
@@ -169,6 +173,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void start_portal();
   void stop_portal();
   bool apply_recommended_settings();
+  void set_portal_password(const std::string &password) { portal_password_ = password; }
 
  protected:
   TofSensor *distanceSensor;
@@ -204,6 +209,8 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void register_server_endpoints();
   bool portal_enabled_{false};
   bool portal_registered_{false};
+  std::string portal_password_{};
+  bool check_token_(AsyncWebServerRequest *request);
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;

--- a/components/roode/web/portal.html
+++ b/components/roode/web/portal.html
@@ -144,6 +144,13 @@
   </div><!-- /wrap -->
 
   <script>
+  const TOKEN = new URLSearchParams(location.search).get('token') || '';
+  const TOKEN_HEADER = TOKEN ? {'X-Portal-Token': TOKEN} : {};
+  const tokenParam = TOKEN ? `?token=${encodeURIComponent(TOKEN)}` : '';
+  if(TOKEN){
+    const exp = document.getElementById('btnExport');
+    if(exp) exp.href = '/api/export/all'+tokenParam;
+  }
   // Helpers
   const $ = (s)=>document.querySelector(s);
   const showToast = (msg, ok=false)=>{
@@ -175,7 +182,7 @@
   // Fetch JSON with graceful fallback
   async function getJSON(url){
     try {
-      const r = await fetch(url, {cache:'no-store'});
+      const r = await fetch(url, {cache:'no-store', headers: TOKEN_HEADER});
       if(!r.ok) throw new Error(r.status + ' ' + r.statusText);
       return await r.json();
     } catch(e) {
@@ -185,7 +192,9 @@
   }
   async function postJSON(url, body){
     try {
-      const r = await fetch(url, {method:'POST', headers:{'Content-Type':'application/json'}, body: body?JSON.stringify(body):'{}'});
+      const headers = {'Content-Type':'application/json'};
+      if(TOKEN) headers['X-Portal-Token'] = TOKEN;
+      const r = await fetch(url, {method:'POST', headers, body: body?JSON.stringify(body):'{}'});
       if(!r.ok) throw new Error(r.status + ' ' + r.statusText);
       return await r.json().catch(()=>({ok:true}));
     } catch(e) {
@@ -234,7 +243,7 @@
     if(r.thresholds){ $('#pvMin').textContent = r.thresholds.min+'%'; $('#pvMax').textContent = r.thresholds.max+'%'; }
     $('#pvSampling').textContent = r.sampling || '—';
     $('#pvFw').textContent = r.firmware || '—';
-    if(r.download) $('#dlResult').href = r.download;
+    if(r.download) $('#dlResult').href = r.download + (TOKEN ? (r.download.includes('?') ? '&' : '?') + 'token=' + encodeURIComponent(TOKEN) : '');
     if(apply) apply.disabled = false;
   }
   function renderSessions(){
@@ -256,7 +265,7 @@
         <td>${fmtDur(s.duration_sec)}</td>
         <td>${fmtBytes(s.size_bytes)}</td>
         <td class="mono">
-          <a href="/api/scan/session/${encodeURIComponent(s.id)}">Download</a>
+          <a href="/api/scan/session/${encodeURIComponent(s.id)}${tokenParam}">Download</a>
           &nbsp;|&nbsp;<a href="#" data-view="${s.id}">View</a>
           &nbsp;|&nbsp;<a href="#" data-del="${s.id}">Delete</a>
         </td>`;


### PR DESCRIPTION
## Summary
- add configurable portal password/token support
- enforce token on portal and API requests
- propagate token from web UI for authenticated calls

## Testing
- `clang-format -i components/roode/roode.cpp components/roode/roode.h`
- `python -m py_compile components/roode/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_68af0ac9975083309515e878b48aedd9