### PR TITLE
Guard web portal token check behind USE_WEB_SERVER

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -151,8 +151,8 @@ Roode::~Roode() {
   delete exit;
 }
 
-bool Roode::check_token_(AsyncWebServerRequest *request) {
 #ifdef USE_WEB_SERVER
+bool Roode::check_token_(AsyncWebServerRequest *request) {
   if (portal_password_.empty())
     return true;
   if (request->hasHeader("X-Portal-Token") && request->header("X-Portal-Token") == portal_password_.c_str())
@@ -164,10 +164,8 @@ bool Roode::check_token_(AsyncWebServerRequest *request) {
   }
   request->send(401, "text/plain", "Unauthorized");
   return false;
-#else
-  return true;
-#endif
 }
+#endif
 
 void Roode::register_server_endpoints() {
 #ifdef USE_WEB_SERVER

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -210,7 +210,9 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   bool portal_enabled_{false};
   bool portal_registered_{false};
   std::string portal_password_{};
+#ifdef USE_WEB_SERVER
   bool check_token_(AsyncWebServerRequest *request);
+#endif
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;


### PR DESCRIPTION
## Summary
- Avoid compilation errors when the web server is disabled by wrapping token check helpers with `USE_WEB_SERVER`

## Testing
- `esphome compile /tmp/test_no_web.yaml` *(fails: 'TemplateButton' does not name a type)*

------
https://chatgpt.com/codex/tasks/task_e_68af10a205f883309998e3c48e9e1e83