### PR TITLE
Add complete calibration button

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ sense objects toward the upper left, you should pick a center SPAD in the lower 
 | [Persistent calibration](#persistent-calibration) | Calibration data can persist in flash across reboots |
 | [Automatic calibration (Home Assistant Setup)](#automatic-calibration-home-assistant-setup) | Portal-guided scan sets ROI and thresholds automatically |
 | [Manual recalibration button](#manual-recalibration-button) | Exposes a `Recalibrate` button for on-demand calibration |
+| [Complete calibration button](#complete-calibration-button) | Runs scan, analysis, and applies settings in one step |
 | [Dual-core tasking](#dual-core-tasking) | Keeps polling responsive on ESP32 with automatic retry/fallback |
 | [Filtering options](#filtering-options) | Median/percentile filters smooth jitter with adjustable window |
 | [FSM timeouts](#fsm-timeouts) | Resets the state machine when a transition stalls |
@@ -746,6 +747,9 @@ After each reboot, leave the monitored area empty for about 10 seconds so the s
 
 ### Manual recalibration button
 Provides a `Recalibrate` button for on-demand recalibration, complementing automatic scans.
+
+### Complete calibration button
+Runs a scan, analyzes the result, and applies the recommended ROI and thresholds in one step.
 
 ### Dual-core tasking
 On ESP32 platforms polling runs on a separate core to keep response times fast with automatic retry and fallback.

--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -181,6 +181,26 @@ async def to_code(config: Dict):
         )
     )
 
+    button_id = ID(f"{config[CONF_ID].id}_complete_calibration")
+    button_id.type = template_button.TemplateButton
+    btn_conf = {
+        CONF_ID: button_id,
+        CONF_NAME: "Complete Calibration",
+        CONF_ICON: "mdi:auto-fix",
+        CONF_DISABLED_BY_DEFAULT: False,
+    }
+    complete_button = await button.new_button(btn_conf)
+    cg.add(
+        complete_button.set_entity_category(
+            cg.EntityCategory.ENTITY_CATEGORY_CONFIG
+        )
+    )
+    cg.add(
+        complete_button.add_on_press_callback(
+            cg.RawExpression(f"std::bind(&{Roode}::complete_calibration, {roode})")
+        )
+    )
+
     button_id = ID(f"{config[CONF_ID].id}_recalibrate")
     button_id.type = template_button.TemplateButton
     btn_conf = {

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -461,6 +461,7 @@ void Roode::setup() {
   // USE_API_SERVICES compile-time flag is disabled.
 #ifdef USE_API_SERVICES
   this->register_service(&Roode::start_passive_scan, "start_passive_scan");
+  this->register_service(&Roode::complete_calibration, "complete_calibration");
 #endif
 #ifdef USE_WEB_SERVER
   if (portal_enabled_ && web_server_base::global_web_server_base != nullptr) {
@@ -1576,6 +1577,11 @@ void Roode::start_passive_scan() {
   scan_progress_ = 1.0f;
   save_current_scan_session();
   scan_running = false;
+}
+
+void Roode::complete_calibration() {
+  start_passive_scan();
+  apply_recommended_settings();
 }
 
 void Roode::save_current_scan_session() {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -166,6 +166,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void reset_cpu_optimizations(float cpu);
   void update_metrics();
   void start_passive_scan();
+  void complete_calibration();
   Zone *entry = new Zone(0);
   Zone *exit = new Zone(1);
   static void log_event(const std::string &msg);

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -82,14 +82,16 @@ low. The portal and endpoints are only loaded while the switch is on.
 
 ## Passive Scan Trigger
 
-Roode exposes `Start Passive Scan` and `Recalibrate` button entities that
-request a scan session or rerun the calibration directly from the device.
-Both buttons are enabled by default, so Home Assistant will automatically
-surface them in the interface. Pressing the scan button creates a
+Roode exposes `Start Passive Scan`, `Complete Calibration`, and `Recalibrate`
+button entities that request a scan session, perform a full calibration, or
+rerun the calibration directly from the device. All buttons are enabled by
+default, so Home Assistant will automatically surface them in the interface.
+Pressing the scan button creates a
 timestamped `passive_scan_YYYY-MM-DD_HH-MM/` directory with an empty
 `session.json` and dispatches an `esphome.<node>_start_passive_scan`
 command to the ESPHome node. The `Recalibrate` button immediately invokes
-the device's calibration routine.
+the device's calibration routine. The `Complete Calibration` button runs a
+scan and automatically applies the recommended ROI and thresholds.
 
 ## Calibration Portal
 

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -47,6 +47,9 @@ captive_portal:
       - service: start_passive_scan
         then:
           - lambda: "id(roode_platform)->start_passive_scan();"
+      - service: complete_calibration
+        then:
+          - lambda: "id(roode_platform)->complete_calibration();"
 
 ota:
   password: !secret ota_password

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -44,6 +44,9 @@ api:
     - service: start_passive_scan
       then:
         - lambda: "id(roode_platform)->start_passive_scan();"
+    - service: complete_calibration
+      then:
+        - lambda: "id(roode_platform)->complete_calibration();"
 
 ota:
   password: !secret ota_password

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -44,6 +44,9 @@ api:
     - service: start_passive_scan
       then:
         - lambda: "id(roode_platform)->start_passive_scan();"
+    - service: complete_calibration
+      then:
+        - lambda: "id(roode_platform)->complete_calibration();"
 
 ota:
   password: !secret ota_password

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -41,6 +41,9 @@ api:
     - service: start_passive_scan
       then:
         - lambda: "id(roode_platform)->start_passive_scan();"
+    - service: complete_calibration
+      then:
+        - lambda: "id(roode_platform)->complete_calibration();"
 
 ota:
   password: !secret ota_password


### PR DESCRIPTION
## Summary
- add a `complete_calibration` service and button to run scan and apply settings in one step
- document new button in README and Home Assistant guide
- update example YAML configs with `complete_calibration` API service

## Testing
- `python -m py_compile components/roode/__init__.py`
- `esphome compile peopleCounter32.yaml` *(fails: 'ota' requires a 'platform' key but it was not specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af1a4f5d8083308a5c28c85332340f