### PR TITLE
Add runtime log for web portal

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -421,6 +421,9 @@ void Roode::start_portal() {
   if (web_server_base::global_web_server_base != nullptr) {
     web_server_base::global_web_server_base->init();
     register_server_endpoints();
+    ESP_LOGI(TAG, "Web server routes registered");
+  } else {
+    ESP_LOGW(TAG, "Web server base not initialized, portal start deferred");
   }
 #endif
 }


### PR DESCRIPTION
## Summary
- log web server route registration when starting portal
- warn when web server base pointer is missing

## Testing
- `esphome compile peopleCounter32.yaml` *(fails: 'ota' requires a 'platform' key but it was not specified)*

------
https://chatgpt.com/codex/tasks/task_e_68af1bd7dd0c8330a04cbb91924df90e