### PR TITLE
Always enable web portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.3
+- Always enable web portal; remove portal switch toggle
+
 ## 1.6.2
 - Add ArduinoJson dependency to resolve missing header during compile
 

--- a/README.md
+++ b/README.md
@@ -147,33 +147,12 @@ external_components:
     refresh: always
     ref: master
 
-# Optional web portal controlled by a template switch
+# Built-in web portal
 web_server:
   port: 80
   auth:
     username: admin
     password: !secret web_password
-
-globals:
-  - id: portal_on
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-switch:
-  - platform: template
-    id: portal_switch
-    name: Portal
-    lambda: |-
-      return id(portal_on);
-    turn_on_action:
-      - lambda: |-
-          id(portal_on) = true;
-          id(roode_platform).start_portal();
-    turn_off_action:
-      - lambda: |-
-          id(portal_on) = false;
-          id(roode_platform).stop_portal();
 
 # Convenience restart button
 button:
@@ -739,7 +718,7 @@ Calibration data can persist in flash across reboots so ROI thresholds survive p
 Roode can determine its own idle distance and zone thresholds. The sensor recalibrates itself after power-up and periodically during operation, so no manual tuning is required. The steps below show how to enable the automatic calibration workflow in Home Assistant without any coding knowledge:
 
 1. **Flash Roode using the example YAML** from the Quick Start above.
-2. **Enable the calibration portal** by turning on the `Portal` switch exposed by the device.
+2. **Open the calibration portal** at `http://<device>/portal`.
 3. **Run a scan**: in the portal press *Start Scan*, walk through the doorway once, and wait for the result.
 4. **Apply the result**: click *Accept ROI* to apply the automatically calculated region of interest and thresholds. The device updates itself via OTA and begins counting immediately.
 
@@ -802,12 +781,9 @@ Normal info appears in green, details in yellow and failures in red for readabil
 ## Web Portal & API
 
 Roode includes a lightweight web portal for configuration and calibration.
-To conserve resources the web server is stopped on boot and only started
-when the `portal_switch` is turned on. The example YAML files define this
-template switch and tie it to `roode_platform.start_portal()`/`stop_portal()`,
-which handle starting and stopping the ESPHome web server internally.
+The portal starts automatically when the device boots.
 
-When enabled the portal responds on `/portal` (or `/`) and exposes several
+The portal responds on `/portal` (or `/`) and exposes several
 JSON endpoints:
 
 - `/api/settings/current` – current firmware and ROI settings.
@@ -828,11 +804,6 @@ Calibration follows a passive-scan → recommendation → apply cycle:
 3. Apply them via `/api/roi/apply` to write the settings to flash.
 
 Set `portal_password` in the `roode:` configuration to require a token for these requests. Clients supply it via a `token` query parameter or `X-Portal-Token` header. When omitted, the portal remains open to any client while it is running.
-
-Leave the switch off during normal operation to keep memory and CPU usage
-low. If the ESPHome `api:` component is enabled, the `Portal` switch is
-also published as a Home Assistant entity for easy toggling from the UI or
-automations.
 
 ## Logging and Diagnostics
 
@@ -863,7 +834,7 @@ these sensors. For automatic recovery features, see [Polling timeout recovery](#
 
 The built-in portal handles most calibration tasks using a passive-scan → recommendation → apply flow:
 
-1. Enable the `Portal` switch in Home Assistant or via the device API.
+1. Open the portal at `http://<device>/portal`.
 2. Start a passive scan from the portal and walk through the doorway once.
 3. Review the previewed region of interest and thresholds, then press *Apply* to save them.
 

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -415,29 +415,6 @@ void Roode::register_server_endpoints() {
 #endif
 }
 
-void Roode::start_portal() {
-  portal_enabled_ = true;
-#ifdef USE_WEB_SERVER
-  if (web_server_base::global_web_server_base != nullptr) {
-    web_server_base::global_web_server_base->init();
-    register_server_endpoints();
-    ESP_LOGI(TAG, "Web server routes registered");
-  } else {
-    ESP_LOGW(TAG, "Web server base not initialized, portal start deferred");
-  }
-#endif
-}
-
-void Roode::stop_portal() {
-  portal_enabled_ = false;
-#ifdef USE_WEB_SERVER
-  if (web_server_base::global_web_server_base != nullptr) {
-    web_server_base::global_web_server_base->deinit();
-  }
-  portal_registered_ = false;
-#endif
-}
-
 void Roode::set_auto_calibration_interval_sec(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
 void Roode::dump_config() {
   ESP_LOGCONFIG(TAG, "Roode:");
@@ -467,9 +444,11 @@ void Roode::setup() {
   this->register_service(&Roode::complete_calibration, "complete_calibration");
 #endif
 #ifdef USE_WEB_SERVER
-  if (portal_enabled_ && web_server_base::global_web_server_base != nullptr) {
+  if (web_server_base::global_web_server_base != nullptr) {
     web_server_base::global_web_server_base->init();
     register_server_endpoints();
+  } else {
+    ESP_LOGW(TAG, "Web server base not initialized, portal not started");
   }
 #endif
   if (version_sensor != nullptr) {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -28,7 +28,7 @@ namespace esphome {
 namespace roode {
 #define NOBODY 0
 #define SOMEONE 1
-#define VERSION "1.6.0"
+#define VERSION "1.6.3"
 static const char *const TAG = "Roode";
 static const char *const SETUP = "Setup";
 static const char *const CALIBRATION = "Sensor Calibration";
@@ -171,8 +171,6 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   Zone *exit = new Zone(1);
   static void log_event(const std::string &msg);
 
-  void start_portal();
-  void stop_portal();
   bool apply_recommended_settings();
   void set_portal_password(const std::string &password) { portal_password_ = password; }
 
@@ -208,7 +206,6 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   sensor::Sensor *scan_time_cap_seconds_sensor{nullptr};
 
   void register_server_endpoints();
-  bool portal_enabled_{false};
   bool portal_registered_{false};
   std::string portal_password_{};
 #ifdef USE_WEB_SERVER

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -23,47 +23,15 @@ Roode now exposes button entities to start a passive scan or force a recalibrati
       newCount: "{{ states('input_number.set_people32') | int }}"
 ```
 
-## Portal Switch and REST API
+## Portal and REST API
 
-Roode ships with an optional web portal that serves a small HTML page and a
-REST API for configuration and calibration tasks. The web server is disabled
-on boot to save memory; enable it only when needed.
-
-### Enabling the portal
-
-The example firmware defines a `portal_switch` template switch. Turning this
-switch on starts the web server and registers the portal; turning it off stops
-both the server and the portal logic:
-
-```yaml
-globals:
-  - id: portal_on
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-switch:
-  - platform: template
-    id: portal_switch
-    name: Portal
-    lambda: |-
-      return id(portal_on);
-    turn_on_action:
-      - lambda: |-
-          id(portal_on) = true;
-          id(roode_platform).start_portal();
-    turn_off_action:
-      - lambda: |-
-          id(portal_on) = false;
-          id(roode_platform).stop_portal();
-```
-
-If the ESPHome `api:` component is enabled, this `Portal` switch is exposed to
-Home Assistant and can be toggled from the UI or via automations.
+Roode ships with a web portal that serves a small HTML page and a
+REST API for configuration and calibration tasks. The portal starts
+automatically when the device boots.
 
 ### Endpoints
 
-When the portal is active the device serves:
+The portal exposes:
 
 - `/portal` or `/` – simple HTML configuration page.
 - `/api/settings/current` – current firmware and ROI settings.
@@ -76,9 +44,6 @@ When the portal is active the device serves:
 - `/api/scan/session/<id>` – retrieve a specific session.
 - `/api/scan/delete` *(POST)* – delete all stored sessions.
 - `/api/export/all` – export all session data as JSON.
-
-Leave the `portal_switch` off during normal operation to keep resource usage
-low. The portal and endpoints are only loaded while the switch is on.
 
 ## Passive Scan Trigger
 
@@ -95,8 +60,8 @@ scan and automatically applies the recommended ROI and thresholds.
 
 ## Calibration Portal
 
-Enable the `Portal` switch and visit `http://<device>/portal` to access the
-built-in calibration portal. The page provides buttons to start a passive
+Visit `http://<device>/portal` to access the built-in calibration portal.
+The page provides buttons to start a passive
 scan, review the suggested region of interest and apply the result—no extra
 Lovelace views or helper scripts are required.
 

--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -11,15 +11,6 @@ external_components:
 
 esphome:
   name: $devicename
-  on_boot:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(portal_on);'
-          then:
-            - lambda: 'id(roode_platform).start_portal();'
-          else:
-            - lambda: 'id(roode_platform).stop_portal();'
 
 esp32:
   board: wemos_d1_mini32
@@ -59,27 +50,6 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
-
-globals:
-  - id: portal_on
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-switch:
-  - platform: template
-    id: portal_switch
-    name: Portal
-    lambda: |-
-      return id(portal_on);
-    turn_on_action:
-      - lambda: |-
-          id(portal_on) = true;
-          id(roode_platform).start_portal();
-    turn_off_action:
-      - lambda: |-
-          id(portal_on) = false;
-          id(roode_platform).stop_portal();
 
 # Enable logging
 logger:

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -8,15 +8,6 @@ external_components:
 
 esphome:
   name: $devicename
-  on_boot:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(portal_on);'
-          then:
-            - lambda: 'id(roode_platform).start_portal();'
-          else:
-            - lambda: 'id(roode_platform).stop_portal();'
 
 esp32:
   board: wemos_d1_mini32
@@ -56,27 +47,6 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
-
-globals:
-  - id: portal_on
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-switch:
-  - platform: template
-    id: portal_switch
-    name: Portal
-    lambda: |-
-      return id(portal_on);
-    turn_on_action:
-      - lambda: |-
-          id(portal_on) = true;
-          id(roode_platform).start_portal();
-    turn_off_action:
-      - lambda: |-
-          id(portal_on) = false;
-          id(roode_platform).stop_portal();
 
 # Enable logging
 logger:

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -13,15 +13,6 @@ esphome:
   name: $devicename
   platform: ESP8266
   board: d1_mini
-  on_boot:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(portal_on);'
-          then:
-            - lambda: 'id(roode_platform).start_portal();'
-          else:
-            - lambda: 'id(roode_platform).stop_portal();'
 
 wifi:
   networks:
@@ -56,27 +47,6 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
-
-globals:
-  - id: portal_on
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-switch:
-  - platform: template
-    id: portal_switch
-    name: Portal
-    lambda: |-
-      return id(portal_on);
-    turn_on_action:
-      - lambda: |-
-          id(portal_on) = true;
-          id(roode_platform).start_portal();
-    turn_off_action:
-      - lambda: |-
-          id(portal_on) = false;
-          id(roode_platform).stop_portal();
 
 # Enable logging
 logger:

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -10,15 +10,6 @@ esphome:
   name: $devicename
   platform: ESP8266
   board: d1_mini
-  on_boot:
-    then:
-      - if:
-          condition:
-            lambda: 'return id(portal_on);'
-          then:
-            - lambda: 'id(roode_platform).start_portal();'
-          else:
-            - lambda: 'id(roode_platform).stop_portal();'
 
 wifi:
   networks:
@@ -53,27 +44,6 @@ web_server:
   auth:
     username: admin
     password: !secret web_password
-
-globals:
-  - id: portal_on
-    type: bool
-    restore_value: yes
-    initial_value: 'false'
-
-switch:
-  - platform: template
-    id: portal_switch
-    name: Portal
-    lambda: |-
-      return id(portal_on);
-    turn_on_action:
-      - lambda: |-
-          id(portal_on) = true;
-          id(roode_platform).start_portal();
-    turn_off_action:
-      - lambda: |-
-          id(portal_on) = false;
-          id(roode_platform).stop_portal();
 
 # Enable logging
 logger:


### PR DESCRIPTION
## Summary
- remove portal switch and globals from example YAML
- start web portal automatically at boot
- update documentation and changelog

## Testing
- `pio run -e roode` *(fails: esphome components missing)*

------
https://chatgpt.com/codex/tasks/task_e_68af1db6af448330b18584b1331b7c00