### PR TITLE
Include ESPHome portal assets in sample configs

### DIFF
--- a/peopleCounter32.yaml
+++ b/peopleCounter32.yaml
@@ -37,10 +37,12 @@ api:
         - lambda: "id(roode_platform)->recalibration();"
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 web_server:
   port: 80
+  include_internal: true
   auth:
     username: admin
     password: !secret web_password

--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -34,10 +34,12 @@ api:
         - lambda: "id(roode_platform)->recalibration();"
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 web_server:
   port: 80
+  include_internal: true
   auth:
     username: admin
     password: !secret web_password

--- a/peopleCounter8266.yaml
+++ b/peopleCounter8266.yaml
@@ -34,10 +34,12 @@ api:
         - lambda: "id(roode_platform)->recalibration();"
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 web_server:
   port: 80
+  include_internal: true
   auth:
     username: admin
     password: !secret web_password

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -31,10 +31,12 @@ api:
         - lambda: "id(roode_platform)->recalibration();"
 
 ota:
-  password: !secret ota_password
+  - platform: esphome
+    password: !secret ota_password
 
 web_server:
   port: 80
+  include_internal: true
   auth:
     username: admin
     password: !secret web_password


### PR DESCRIPTION
## Summary
- add `include_internal: true` to web_server blocks so portal assets are served
- update OTA sections to new `esphome` platform format

## Testing
- `esphome config peopleCounter32.yaml` *(fails: [sensor_id] is an invalid option for [vl53l1x])*

------
https://chatgpt.com/codex/tasks/task_e_68af90b672bc8330b913e68e0a7c5d0d