### PR TITLE
Log calibration setting application results

### DIFF
--- a/calibration/OffsetAndXtalkCalibration/OffsetAndXtalkCalibration.ino
+++ b/calibration/OffsetAndXtalkCalibration/OffsetAndXtalkCalibration.ino
@@ -24,10 +24,23 @@ void setup()
     Serial.readString();
     int16_t foundOffset;
     sensor_status = sensor.CalibrateOffset(140, &foundOffset);
-
-
-    Serial.println("Calibrated offset: " + String(foundOffset));
-    Serial.println("Set this offset in the sensor configuration under offset: <value>");
+    if (sensor_status == VL53L1_ERROR_NONE)
+    {
+        Serial.println("Calibrated offset: " + String(foundOffset));
+        sensor_status = sensor.SetOffsetInMm(foundOffset);
+        if (sensor_status == VL53L1_ERROR_NONE)
+        {
+            Serial.printf("Offset %d set and active\n", foundOffset);
+        }
+        else
+        {
+            Serial.printf("Failed to set offset, error code: %d\n", sensor_status);
+        }
+    }
+    else
+    {
+        Serial.printf("Offset calibration failed, error code: %d\n", sensor_status);
+    }
 
     /* The target distance : the distance where the sensor start to "under range"
     Crosstalk calibration should be conducted in a dark environment, with no IR contribution.
@@ -42,8 +55,23 @@ void setup()
     uint16_t CalibrationDistance = 140; // crosstalk calibration distance
     uint16_t foundXTalk;
     sensor_status = sensor.CalibrateXTalk(CalibrationDistance, &foundXTalk);
-    Serial.println("Calibrated offset: " + String(foundXTalk));
-    Serial.println("Set this offset in the sensor configuration under crosstalk: <value>");
+    if (sensor_status == VL53L1_ERROR_NONE)
+    {
+        Serial.println("Calibrated crosstalk: " + String(foundXTalk));
+        sensor_status = sensor.SetXTalk(foundXTalk);
+        if (sensor_status == VL53L1_ERROR_NONE)
+        {
+            Serial.printf("Crosstalk %d set and active\n", foundXTalk);
+        }
+        else
+        {
+            Serial.printf("Failed to set crosstalk, error code: %d\n", sensor_status);
+        }
+    }
+    else
+    {
+        Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
+    }
 }
 void loop()
 {

--- a/calibration/src/OffsetAndXtalkCalibration.cpp
+++ b/calibration/src/OffsetAndXtalkCalibration.cpp
@@ -24,11 +24,23 @@ void setup()
     Serial.readString();
     int16_t foundOffset;
     sensor_status = sensor.CalibrateOffset(140, &foundOffset);
-
-    sensor.SetOffsetInMm(foundOffset);
-
-    Serial.println("Calibrated offset: " + String(foundOffset));
-    Serial.printf("Set this offset in the sensor configuration under offset: %d\n", foundOffset);
+    if (sensor_status == VL53L1_ERROR_NONE)
+    {
+        Serial.println("Calibrated offset: " + String(foundOffset));
+        sensor_status = sensor.SetOffsetInMm(foundOffset);
+        if (sensor_status == VL53L1_ERROR_NONE)
+        {
+            Serial.printf("Offset %d set and active\n", foundOffset);
+        }
+        else
+        {
+            Serial.printf("Failed to set offset, error code: %d\n", sensor_status);
+        }
+    }
+    else
+    {
+        Serial.printf("Offset calibration failed, error code: %d\n", sensor_status);
+    }
 
     /* The target distance : the distance where the sensor start to "under range"
     Crosstalk calibration should be conducted in a dark environment, with no IR contribution.
@@ -43,9 +55,23 @@ void setup()
     uint16_t CalibrationDistance = 140; // crosstalk calibration distance
     uint16_t foundXTalk;
     sensor_status = sensor.CalibrateXTalk(CalibrationDistance, &foundXTalk);
-    Serial.println("Calibrated offset: " + String(foundXTalk));
-    Serial.printf("Set this offset in the sensor configuration under crosstalk: %d\n", foundXTalk);
-    sensor.SetXTalk(foundXTalk);
+    if (sensor_status == VL53L1_ERROR_NONE)
+    {
+        Serial.println("Calibrated crosstalk: " + String(foundXTalk));
+        sensor_status = sensor.SetXTalk(foundXTalk);
+        if (sensor_status == VL53L1_ERROR_NONE)
+        {
+            Serial.printf("Crosstalk %d set and active\n", foundXTalk);
+        }
+        else
+        {
+            Serial.printf("Failed to set crosstalk, error code: %d\n", sensor_status);
+        }
+    }
+    else
+    {
+        Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
+    }
     sensor.StartRanging();
 }
 void loop()


### PR DESCRIPTION
## Summary
- Log calculated offset and crosstalk values during calibration
- Apply calculated settings to the sensor and report success or failure

## Testing
- `pio run -d calibration`


------
https://chatgpt.com/codex/tasks/task_e_68af28957f4c8330838c811079c5ed5f