### PR TITLE
Ensure portal endpoint registration after web server init

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -603,6 +603,12 @@ void Roode::update() {
 }
 
 void Roode::loop() {
+#ifdef USE_WEB_SERVER
+  if (!portal_registered_ && web_server_base::global_web_server_base != nullptr) {
+    web_server_base::global_web_server_base->init();
+    register_server_endpoints();
+  }
+#endif
   if (use_sensor_task_) {
     // When running on dual core the sensor loop runs in a separate task
     // Skip execution from main loop


### PR DESCRIPTION
## Summary
- Register portal routes during loop once the web server is available to expose `/portal`

## Testing
- `pio run -e roode` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afb5ddfea48330927067986a8db140