### PR TITLE
Fix portal route registration for calibration portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.4
+- Ensure calibration portal registers before the default web page so `/portal` shows the portal and the root URL redirects to it
+
 ## 1.6.3
 - Always enable web portal; remove portal switch toggle
 

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -191,7 +191,7 @@ void Roode::register_server_endpoints() {
   server->on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
     if (!check_token_(request))
       return;
-    request->send_P(200, "text/html", portal_html);
+    request->redirect("/portal");
   });
 
   portal_registered_ = true;
@@ -456,8 +456,8 @@ void Roode::setup() {
 #endif
 #ifdef USE_WEB_SERVER
   if (web_server_base::global_web_server_base != nullptr) {
-    web_server_base::global_web_server_base->init();
     register_server_endpoints();
+    web_server_base::global_web_server_base->init();
   } else {
     ESP_LOGW(TAG, "Web server base not initialized, portal not started");
   }
@@ -616,8 +616,8 @@ void Roode::update() {
 void Roode::loop() {
 #ifdef USE_WEB_SERVER
   if (!portal_registered_ && web_server_base::global_web_server_base != nullptr) {
-    web_server_base::global_web_server_base->init();
     register_server_endpoints();
+    web_server_base::global_web_server_base->init();
   }
 #endif
   if (use_sensor_task_) {


### PR DESCRIPTION
## Summary
- Register portal endpoints before starting the web server and redirect root URL to `/portal`
- Document portal registration fix in changelog

## Testing
- `platformio run -e roode` *(fails: esphome headers missing)*
- `esphome compile peopleCounter32.yaml` *(fails: ota requires platform key)*

------
https://chatgpt.com/codex/tasks/task_e_68afb97f84488330847d5dbaea917083