### PR TITLE
Expose portal via web server rewrites

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -193,15 +193,12 @@ void Roode::register_server_endpoints() {
   });
   base->add_handler(portal_slash_handler);
 
-  auto *root_handler = new AsyncCallbackWebHandler();
-  root_handler->setUri("/");
-  root_handler->setMethod(HTTP_GET);
-  root_handler->onRequest([this](AsyncWebServerRequest *request) {
-    if (!check_token_(request))
-      return;
-    request->redirect("/portal");
-  });
-  base->add_handler(root_handler);
+  // Rewrite root requests to the portal to ensure it is always exposed.
+  auto server = base->get_server();
+  if (server != nullptr) {
+    server->rewrite("/", "/portal");
+    server->rewrite("/portal/", "/portal");
+  }
 
   portal_registered_ = true;
 
@@ -504,8 +501,9 @@ void Roode::setup() {
 #endif
 #ifdef USE_WEB_SERVER
   if (web_server_base::global_web_server_base != nullptr) {
+    auto *base = web_server_base::global_web_server_base;
+    base->init();
     register_server_endpoints();
-    web_server_base::global_web_server_base->init();
   } else {
     ESP_LOGW(TAG, "Web server base not initialized, portal not started");
   }
@@ -664,8 +662,9 @@ void Roode::update() {
 void Roode::loop() {
 #ifdef USE_WEB_SERVER
   if (!portal_registered_ && web_server_base::global_web_server_base != nullptr) {
+    auto *base = web_server_base::global_web_server_base;
+    base->init();
     register_server_endpoints();
-    web_server_base::global_web_server_base->init();
   }
 #endif
   if (use_sensor_task_) {

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -83,7 +83,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void dump_config() override;
   ~Roode();
   /** Roode uses data from sensors */
-  float get_setup_priority() const override { return setup_priority::PROCESSOR; };
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI - 1.0f; };
 
   TofSensor *get_tof_sensor() { return this->distanceSensor; }
   void set_tof_sensor(TofSensor *sensor) { this->distanceSensor = sensor; }


### PR DESCRIPTION
## Summary
- ensure web server initializes before registering portal endpoints
- rewrite root requests to `/portal` so calibration portal is always served
- adjust setup priority to run after WiFi

## Testing
- `esphome compile peopleCounter32Dev.yaml` *(fails: Unknown pin mode OUTPUT_PULLUP)*

------
https://chatgpt.com/codex/tasks/task_e_68b226753c6c83308fcc83c33e8589f2