### PR TITLE
fix: disable root rewrite for calibration portal

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -193,13 +193,6 @@ void Roode::register_server_endpoints() {
   });
   base->add_handler(portal_slash_handler);
 
-  // Rewrite root requests to the portal to ensure it is always exposed.
-  auto server = base->get_server();
-  if (server != nullptr) {
-    server->rewrite("/", "/portal");
-    server->rewrite("/portal/", "/portal");
-  }
-
   portal_registered_ = true;
 
   auto *settings_handler = new AsyncCallbackWebHandler();
@@ -502,8 +495,8 @@ void Roode::setup() {
 #ifdef USE_WEB_SERVER
   if (web_server_base::global_web_server_base != nullptr) {
     auto *base = web_server_base::global_web_server_base;
-    base->init();
     register_server_endpoints();
+    base->init();
   } else {
     ESP_LOGW(TAG, "Web server base not initialized, portal not started");
   }
@@ -663,8 +656,8 @@ void Roode::loop() {
 #ifdef USE_WEB_SERVER
   if (!portal_registered_ && web_server_base::global_web_server_base != nullptr) {
     auto *base = web_server_base::global_web_server_base;
-    base->init();
     register_server_endpoints();
+    base->init();
   }
 #endif
   if (use_sensor_task_) {


### PR DESCRIPTION
## Summary
- serve calibration portal only at /portal without rewriting the root path
- register calibration portal before the web server starts so the default UI remains at /

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b231f10cf88330aa549a316d348aa8