### PR TITLE
Redirect root path to portal and document web_server prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,9 +781,19 @@ Normal info appears in green, details in yellow and failures in red for readabil
 ## Web Portal & API
 
 Roode includes a lightweight web portal for configuration and calibration.
-The portal starts automatically when the device boots.
+It requires the ESPHome `web_server` component:
 
-The portal responds on `/portal` (or `/`) and exposes several
+```yaml
+web_server:
+  port: 80
+  auth:
+    username: admin
+    password: !secret web_password
+```
+
+With `web_server` enabled, the portal starts automatically when the device boots.
+
+The portal responds on `/portal` (the root path redirects here) and exposes several
 JSON endpoints:
 
 - `/api/settings/current` – current firmware and ROI settings.

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -193,6 +193,16 @@ void Roode::register_server_endpoints() {
   });
   base->add_handler(portal_slash_handler);
 
+  auto *root_handler = new AsyncCallbackWebHandler();
+  root_handler->setUri("/");
+  root_handler->setMethod(HTTP_GET);
+  root_handler->onRequest([this](AsyncWebServerRequest *request) {
+    if (!check_token_(request))
+      return;
+    request->redirect("/portal");
+  });
+  base->add_handler(root_handler);
+
   portal_registered_ = true;
 
   auto *settings_handler = new AsyncCallbackWebHandler();

--- a/home_assistant.md
+++ b/home_assistant.md
@@ -26,8 +26,18 @@ Roode now exposes button entities to start a passive scan or force a recalibrati
 ## Portal and REST API
 
 Roode ships with a web portal that serves a small HTML page and a
-REST API for configuration and calibration tasks. The portal starts
-automatically when the device boots.
+REST API for configuration and calibration tasks. It requires the ESPHome
+`web_server` component:
+
+```yaml
+web_server:
+  port: 80
+  auth:
+    username: admin
+    password: !secret web_password
+```
+
+With `web_server` enabled, the portal starts automatically when the device boots.
 
 ### Endpoints
 


### PR DESCRIPTION
## Summary
- Redirect root path to `/portal`
- Document `web_server` requirement with example config

## Testing
- `pytest`
- `pio run -e roode` *(fails: esphome/components headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b31babb77083308ef5e08270fcc8b2