### PR TITLE
Handle calibration failures with threshold rollback

### DIFF
--- a/Documents/diagram.puml
+++ b/Documents/diagram.puml
@@ -24,7 +24,7 @@ class Configuration {
 
 class Zone {
     + Zone(Configuration *configuration)
-    + void calibrateThreshold(VL53L1X_ULD distanceSensor)
+    + bool calibrateThreshold(VL53L1X_ULD distanceSensor)
     + void calibrateRoi(VL53L1X_ULD distanceSensor)
     + uint16_t getMaxThreshold()
     + uint16_t getMinThreshold()

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -889,7 +889,10 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   ESP_LOGI(CALIBRATION, "Calibration triggered for zone %d", zone_id);
   Zone *z = zone_id == 0 ? entry : exit;
   z->reset_roi(zone_id == 0 ? (orientation_ == Parallel ? 167 : 195) : (orientation_ == Parallel ? 231 : 60));
-  z->calibrateThreshold(distanceSensor, 50);
+  if (!z->calibrateThreshold(distanceSensor, 50)) {
+    ESP_LOGW(CALIBRATION, "Calibration failed for zone %d", zone_id);
+    return;
+  }
   // Recalculate ROI sizes so thresholds remain consistent
   entry->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
   exit->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
@@ -1073,9 +1076,15 @@ void Roode::calibrate_zones() {
   calibrateDistance();
 
   entry->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
-  entry->calibrateThreshold(distanceSensor, 50);
+  if (!entry->calibrateThreshold(distanceSensor, 50)) {
+    ESP_LOGW(CALIBRATION, "Entry zone calibration failed");
+    return;
+  }
   exit->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
-  exit->calibrateThreshold(distanceSensor, 50);
+  if (!exit->calibrateThreshold(distanceSensor, 50)) {
+    ESP_LOGW(CALIBRATION, "Exit zone calibration failed");
+    return;
+  }
 
   publish_sensor_configuration(entry, exit, true);
   App.feed_wdt();
@@ -1097,8 +1106,12 @@ void Roode::calibrateDistance() {
   auto *const initial = distanceSensor->get_ranging_mode_override().value_or(Ranging::Longest);
   distanceSensor->set_ranging_mode(initial);
 
-  entry->calibrateThreshold(distanceSensor, 50);
-  exit->calibrateThreshold(distanceSensor, 50);
+  bool entry_ok = entry->calibrateThreshold(distanceSensor, 50);
+  bool exit_ok = exit->calibrateThreshold(distanceSensor, 50);
+  if (!entry_ok || !exit_ok) {
+    ESP_LOGW(CALIBRATION, "Distance calibration failed");
+    return;
+  }
 
   if (distanceSensor->get_ranging_mode_override().has_value()) {
     return;

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -70,37 +70,43 @@ void Zone::reset_roi(uint8_t default_center) {
   roi->center = roi_override->center ?: default_center;
 }
 
-void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
+bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
+  Threshold prev = *threshold;
   std::vector<int> zone_distances;
   zone_distances.reserve(number_attempts);
   int sum = 0;
+  bool any_failed = false;
   for (int i = 0; i < number_attempts; i++) {
     this->readDistance(distanceSensor);
     if (sensor_status != VL53L1_ERROR_NONE) {
       ESP_LOGW(CALIBRATION, "Distance read failed during calibration. status: %d", sensor_status);
+      any_failed = true;
       break;
     }
     zone_distances.push_back(this->getDistance());
     sum += zone_distances.back();
-  };
-  if (zone_distances.empty()) {
-    threshold->idle = 0;
-    ESP_LOGW(CALIBRATION, "Calibration failed: no valid distances recorded");
-  } else {
-    int avg = sum / zone_distances.size();
-    threshold->idle = avg;
-    uint8_t max_pct = threshold->max_percentage.value_or(80);
-    uint8_t min_pct = threshold->min_percentage.value_or(15);
-    threshold->max_percentage = max_pct;
-    threshold->min_percentage = min_pct;
-    threshold->max = (avg * max_pct) / 100;
-    threshold->min = (avg * min_pct) / 100;
   }
+  if (zone_distances.empty() || any_failed) {
+    *threshold = prev;
+    distanceSensor->restart();
+    ESP_LOGW(CALIBRATION, "Calibration failed: reverting to previous thresholds");
+    return false;
+  }
+
+  int avg = sum / zone_distances.size();
+  threshold->idle = avg;
+  uint8_t max_pct = threshold->max_percentage.value_or(80);
+  uint8_t min_pct = threshold->min_percentage.value_or(15);
+  threshold->max_percentage = max_pct;
+  threshold->min_percentage = min_pct;
+  threshold->max = (avg * max_pct) / 100;
+  threshold->min = (avg * min_pct) / 100;
 
   ESP_LOGI(CALIBRATION, "Calibrated threshold for zone. zoneId: %d, idle: %d, min: %d (%d%%), max: %d (%d%%)", id,
            threshold->idle, threshold->min,
            threshold->min_percentage.value_or((threshold->min * 100) / threshold->idle), threshold->max,
            threshold->max_percentage.value_or((threshold->max * 100) / threshold->idle));
+  return true;
 }
 
 void Zone::roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation) {

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -37,7 +37,7 @@ class Zone {
   void dump_config() const;
   VL53L1_Error readDistance(TofSensor *distanceSensor);
   void reset_roi(uint8_t default_center);
-  void calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
+  bool calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
   void set_threshold_percentages(uint8_t min_percent, uint8_t max_percent);
   const uint8_t id;


### PR DESCRIPTION
## Summary
- Return a boolean from `Zone::calibrateThreshold` and rollback thresholds on failure
- Restart the TOF sensor and preserve existing thresholds if calibration fails
- Propagate calibration success status to callers to halt further processing

## Testing
- `pio check -e roode`

------
https://chatgpt.com/codex/tasks/task_e_68b666234b30833093617d6a52fba4c7