### PR TITLE
Handle calibration failure with threshold restore

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -894,17 +894,11 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   CalibrationPrefs prev_cal = calibration_data_[zone_id];
 
   bool calibrated = z->calibrateThreshold(distanceSensor, 50);
-  if (!calibrated || z->threshold->idle == 0) {
+  if (!calibrated) {
     ESP_LOGE(CALIBRATION, "Calibration failed for zone %d. Restoring previous settings.", zone_id);
     log_event(std::string("zone_") + std::to_string(zone_id) + "_calibration_failed");
 
-    // Restore previous calibration values
-    z->threshold->idle = prev_cal.baseline_mm;
-    z->threshold->min = prev_cal.threshold_min_mm;
-    z->threshold->max = prev_cal.threshold_max_mm;
     calibration_data_[zone_id] = prev_cal;
-
-    distanceSensor->restart();
 
     if (status_sensor != nullptr)
       status_sensor->publish_state(-1);
@@ -1095,9 +1089,15 @@ void Roode::calibrate_zones() {
   calibrateDistance();
 
   entry->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
-  entry->calibrateThreshold(distanceSensor, 50);
+  if (!entry->calibrateThreshold(distanceSensor, 50)) {
+    ESP_LOGE(CALIBRATION, "Entry zone threshold calibration failed");
+    return;
+  }
   exit->roi_calibration(entry->threshold->idle, exit->threshold->idle, orientation_);
-  exit->calibrateThreshold(distanceSensor, 50);
+  if (!exit->calibrateThreshold(distanceSensor, 50)) {
+    ESP_LOGE(CALIBRATION, "Exit zone threshold calibration failed");
+    return;
+  }
 
   publish_sensor_configuration(entry, exit, true);
   App.feed_wdt();
@@ -1119,8 +1119,12 @@ void Roode::calibrateDistance() {
   auto *const initial = distanceSensor->get_ranging_mode_override().value_or(Ranging::Longest);
   distanceSensor->set_ranging_mode(initial);
 
-  entry->calibrateThreshold(distanceSensor, 50);
-  exit->calibrateThreshold(distanceSensor, 50);
+  bool entry_ok = entry->calibrateThreshold(distanceSensor, 50);
+  bool exit_ok = exit->calibrateThreshold(distanceSensor, 50);
+  if (!entry_ok || !exit_ok) {
+    ESP_LOGE(CALIBRATION, "Distance calibration failed");
+    return;
+  }
 
   if (distanceSensor->get_ranging_mode_override().has_value()) {
     return;

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -71,20 +71,28 @@ void Zone::reset_roi(uint8_t default_center) {
 }
 
 bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
+  // Preserve previous thresholds in case calibration fails
+  Threshold previous = *threshold;
+
   std::vector<int> zone_distances;
   zone_distances.reserve(number_attempts);
   int sum = 0;
+  bool read_failed = false;
+
   for (int i = 0; i < number_attempts; i++) {
     this->readDistance(distanceSensor);
     if (sensor_status != VL53L1_ERROR_NONE) {
       ESP_LOGW(CALIBRATION, "Distance read failed during calibration. status: %d", sensor_status);
+      read_failed = true;
       break;
     }
     zone_distances.push_back(this->getDistance());
     sum += zone_distances.back();
   }
-  if (zone_distances.empty()) {
-    threshold->idle = 0;
+
+  if (zone_distances.empty() || read_failed) {
+    *threshold = previous;
+    distanceSensor->restart();
     ESP_LOGW(CALIBRATION, "Calibration failed: no valid distances recorded");
     return false;
   }
@@ -98,8 +106,7 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
   threshold->max = (avg * max_pct) / 100;
   threshold->min = (avg * min_pct) / 100;
 
-  ESP_LOGI(CALIBRATION,
-           "Calibrated threshold for zone. zoneId: %d, idle: %d, min: %d (%d%%), max: %d (%d%%)", id,
+  ESP_LOGI(CALIBRATION, "Calibrated threshold for zone. zoneId: %d, idle: %d, min: %d (%d%%), max: %d (%d%%)", id,
            threshold->idle, threshold->min,
            threshold->min_percentage.value_or((threshold->min * 100) / threshold->idle), threshold->max,
            threshold->max_percentage.value_or((threshold->max * 100) / threshold->idle));

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -37,6 +37,10 @@ class Zone {
   void dump_config() const;
   VL53L1_Error readDistance(TofSensor *distanceSensor);
   void reset_roi(uint8_t default_center);
+  /**
+   * Calibrate the zone's distance thresholds. Returns true when at least one
+   * valid distance measurement is recorded.
+   */
   bool calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
   void set_threshold_percentages(uint8_t min_percent, uint8_t max_percent);


### PR DESCRIPTION
## Summary
- preserve and restore zone thresholds if calibration reads fail
- restart sensor and surface calibration success via bool return
- propagate calibration failures to callers for zone and distance calibration

## Testing
- `pio run` *(fails: esphome/components headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b66a4218b483309769fa3a4bb05e5d