### PR TITLE
Add web portal switch to control Roode server

### DIFF
--- a/components/roode/__init__.py
+++ b/components/roode/__init__.py
@@ -25,6 +25,7 @@ AUTO_LOAD = [
     "binary_sensor",
     "text_sensor",
     "number",
+    "switch",
     "button",
     "template",
     "async_tcp",
@@ -141,7 +142,6 @@ CONFIG_SCHEMA = cv.Schema(
             }
         ),
         cv.Optional(CONF_TRIAL_BUMP_CV, default=0.20): cv.percentage,
-
         cv.Optional(CONF_SCAN_TIME_CAP_SECONDS, default=90.0): cv.All(
             cv.positive_float, cv.Range(min=60.0, max=180.0)
         ),
@@ -199,9 +199,7 @@ async def to_code(config: Dict):
     }
     complete_button = await button.new_button(btn_conf)
     cg.add(
-        complete_button.set_entity_category(
-            cg.EntityCategory.ENTITY_CATEGORY_CONFIG
-        )
+        complete_button.set_entity_category(cg.EntityCategory.ENTITY_CATEGORY_CONFIG)
     )
     cg.add(
         complete_button.add_on_press_callback(

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -147,7 +147,34 @@ void Roode::log_event(const std::string &msg) {
 Roode::~Roode() {
   delete entry;
   delete exit;
+  stop_portal_server();
+}
+
+void Roode::start_portal_server() {
+  if (portal_server_ != nullptr)
+    return;
+  portal_server_ = new AsyncWebServer(8080);
+  portal_server_->on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
+    ESP_LOGI(TAG, "Portal request from %s", request->client()->remoteIP().toString().c_str());
+    if (!web_username_.empty() && !request->authenticate(web_username_.c_str(), web_password_.c_str())) {
+      ESP_LOGW(TAG, "Portal auth failed from %s", request->client()->remoteIP().toString().c_str());
+      return request->requestAuthentication();
+    }
+    request->send_P(200, "text/html", portal_html);
+  });
+  register_server_endpoints();
+  ESP_LOGI(TAG, "Starting portal web server on port 8080");
+  portal_server_->begin();
+}
+
+void Roode::stop_portal_server() {
+  if (portal_server_ == nullptr)
+    return;
+  ESP_LOGI(TAG, "Stopping portal web server");
+  portal_server_->end();
   delete portal_server_;
+  portal_server_ = nullptr;
+  api_registered_ = false;
 }
 bool Roode::check_token_(AsyncWebServerRequest *request) {
   if (portal_password_.empty())
@@ -498,18 +525,17 @@ void Roode::setup() {
   this->register_service(&Roode::start_passive_scan, "start_passive_scan");
   this->register_service(&Roode::complete_calibration, "complete_calibration");
 #endif
-  portal_server_ = new AsyncWebServer(8080);
-  portal_server_->on("/", HTTP_GET, [this](AsyncWebServerRequest *request) {
-    ESP_LOGI(TAG, "Portal request from %s", request->client()->remoteIP().toString().c_str());
-    if (!web_username_.empty() && !request->authenticate(web_username_.c_str(), web_password_.c_str())) {
-      ESP_LOGW(TAG, "Portal auth failed from %s", request->client()->remoteIP().toString().c_str());
-      return request->requestAuthentication();
-    }
-    request->send_P(200, "text/html", portal_html);
-  });
-  register_server_endpoints();
-  ESP_LOGI(TAG, "Starting portal web server on port 8080");
-  portal_server_->begin();
+  if (portal_switch != nullptr) {
+    portal_switch->publish_state(false);
+    portal_switch->add_on_state_callback([this](bool state) {
+      if (state)
+        start_portal_server();
+      else
+        stop_portal_server();
+    });
+  } else {
+    start_portal_server();
+  }
   if (version_sensor != nullptr) {
     version_sensor->publish_state(VERSION);
   }

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -8,6 +8,7 @@
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/switch/switch.h"
 #include "esphome/core/application.h"
 #include "esphome/core/component.h"
 #include "esphome/core/log.h"
@@ -174,6 +175,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   void set_portal_password(const std::string &password) { portal_password_ = password; }
   void set_web_username(const std::string &username) { web_username_ = username; }
   void set_web_password(const std::string &password) { web_password_ = password; }
+  void set_web_portal_switch(switch_::Switch *sw) { portal_switch = sw; }
 
  protected:
   TofSensor *distanceSensor;
@@ -213,6 +215,9 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   std::string web_username_{};
   std::string web_password_{};
   bool check_token_(AsyncWebServerRequest *request);
+  switch_::Switch *portal_switch{nullptr};
+  void start_portal_server();
+  void stop_portal_server();
 
   struct CalibrationPrefs {
     uint16_t baseline_mm;

--- a/components/roode/switch.py
+++ b/components/roode/switch.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.const import CONF_ID
+from . import Roode, CONF_ROODE_ID
+
+DEPENDENCIES = ["roode"]
+
+CONF_WEB_PORTAL = "web_portal"
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
+        cv.Optional(CONF_WEB_PORTAL): switch.switch_schema(icon="mdi:web").extend(
+            {cv.GenerateID(): cv.declare_id(switch.Switch)}
+        ),
+    }
+)
+
+
+async def _setup_switch(config, key, hub):
+    if key in config:
+        conf = config[key]
+        sw = cg.new_Pvariable(conf[CONF_ID])
+        await switch.register_switch(sw, conf)
+        cg.add(getattr(hub, f"set_{key}_switch")(sw))
+
+
+async def to_code(config):
+    hub = await cg.get_variable(config[CONF_ROODE_ID])
+    await _setup_switch(config, CONF_WEB_PORTAL, hub)


### PR DESCRIPTION
## Summary
- add configurable `web_portal` switch for toggling Roode's web server
- start or stop the portal web server based on switch state and default it off

## Testing
- `pio run -e roode` *(fails: esphome/components/number/number.h: No such file or directory; optional: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b678a84d408330bc7f67912d7666e1