### PR TITLE
Fix web portal switch schema

### DIFF
--- a/components/roode/switch.py
+++ b/components/roode/switch.py
@@ -11,8 +11,8 @@ CONF_WEB_PORTAL = "web_portal"
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
-        cv.Optional(CONF_WEB_PORTAL): switch.switch_schema(icon="mdi:web").extend(
-            {cv.GenerateID(): cv.declare_id(switch.Switch)}
+        cv.Optional(CONF_WEB_PORTAL): switch.switch_schema(
+            switch.Switch, icon="mdi:web"
         ),
     }
 )


### PR DESCRIPTION
## Summary
- pass required class to `switch_schema` for the optional web portal switch

## Testing
- `python -m pytest`
- `python -m py_compile components/roode/switch.py`


------
https://chatgpt.com/codex/tasks/task_e_68b67b8fa66483308fd29d0ffdaebc48