### PR TITLE
Implement PortalSwitch for Roode web portal switch

### DIFF
--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -74,6 +74,11 @@ struct RecommendedSettings {
   std::string ranging_mode;
 };
 
+class PortalSwitch : public switch_::Switch {
+ public:
+  void write_state(bool state) override { this->publish_state(state); }
+};
+
 class Roode : public PollingComponent, public api::CustomAPIDevice {
  public:
   Roode() { instance_ = this; }

--- a/components/roode/switch.py
+++ b/components/roode/switch.py
@@ -2,17 +2,19 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import switch
 from esphome.const import CONF_ID
-from . import Roode, CONF_ROODE_ID
+from . import Roode, CONF_ROODE_ID, roode_ns
 
 DEPENDENCIES = ["roode"]
 
 CONF_WEB_PORTAL = "web_portal"
 
+PortalSwitch = roode_ns.class_("PortalSwitch", switch.Switch)
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
         cv.Optional(CONF_WEB_PORTAL): switch.switch_schema(
-            switch.Switch, icon="mdi:web"
+            PortalSwitch, icon="mdi:web"
         ),
     }
 )


### PR DESCRIPTION
## Summary
- add concrete `PortalSwitch` C++ class implementing `write_state`
- update `switch.py` to use `PortalSwitch` for web portal control

## Testing
- `python -m py_compile components/roode/switch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b67d7afd1483309d0b92d665e21bb5