### PR TITLE
Persist portal switch state across reboots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.7
+- Persist web portal toggle state across reboots, defaulting to off when unset
+
 ## 1.6.6
 - Ensure portal server starts reliably on port 8080 and log all web requests
 - Drop legacy web server integration and serve API endpoints from the portal server

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -532,7 +532,11 @@ void Roode::setup() {
   this->register_service(&Roode::complete_calibration, "complete_calibration");
 #endif
   if (portal_switch != nullptr) {
-    portal_switch->publish_state(false);
+    optional<bool> init = portal_switch->get_initial_state_with_restore_mode();
+    bool enabled = init.has_value() ? *init : false;
+    portal_switch->publish_state(enabled);
+    if (enabled)
+      start_portal_server();
     portal_switch->add_on_state_callback([this](bool state) {
       if (state)
         start_portal_server();

--- a/components/roode/switch.py
+++ b/components/roode/switch.py
@@ -14,7 +14,9 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ROODE_ID): cv.use_id(Roode),
         cv.Optional(CONF_WEB_PORTAL): switch.switch_schema(
-            PortalSwitch, icon="mdi:web"
+            PortalSwitch,
+            icon="mdi:web",
+            default_restore_mode="RESTORE_DEFAULT_OFF",
         ),
     }
 )


### PR DESCRIPTION
## Summary
- restore portal switch state on boot and start server if enabled
- default portal switch to RESTORE_DEFAULT_OFF to persist state

## Testing
- `esphome compile ci/esp32.yaml` *(fails: NetworkInterface.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b685dab1e48330b3d1504013b66361