### PR TITLE
Handle presence during calibration and expose system logs

### DIFF
--- a/components/roode/portal.h
+++ b/components/roode/portal.h
@@ -318,10 +318,14 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
   }
 
   async function fetchLog(){
-    if(!status || !status.id || status.id === '—') return;
-    const sess = await getJSON(`/api/scan/session/${encodeURIComponent(status.id)}${tokenParam}`).catch(()=>null);
-    const txt = (sess && sess.data) ? sess.data : '';
-    $('#logBox').textContent = txt;
+    try {
+      const r = await fetch(`/api/system/logs${tokenParam}`, {cache:'no-store', headers: TOKEN_HEADER});
+      if(!r.ok) throw new Error(r.status + ' ' + r.statusText);
+      const txt = await r.text();
+      $('#logBox').textContent = txt;
+    } catch(e) {
+      showError(e.message);
+    }
   }
 
   // Polling

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -24,6 +24,7 @@ bool Roode::log_fallback_events_ = false;
 Roode *Roode::instance_ = nullptr;
 static bool scan_running = false;
 static bool scan_cancel_requested = false;
+std::vector<std::string> Roode::log_buffer_;
 
 static std::string format_timestamp(uint32_t sec_since_boot) {
   if (sec_since_boot == 0)
@@ -131,6 +132,10 @@ void Roode::log_event(const std::string &msg) {
 
   std::string colored = std::string(color) + out + "\033[0m";
   ESP_LOGI(TAG, "%s", colored.c_str());
+  std::string line = format_timestamp(millis() / 1000) + " " + out;
+  log_buffer_.push_back(line);
+  if (log_buffer_.size() > 200)
+    log_buffer_.erase(log_buffer_.begin());
   if (instance_ != nullptr) {
     if (msg.find("reinitialize") != std::string::npos) {
       instance_->update_status_text("reinitializing");
@@ -142,6 +147,15 @@ void Roode::log_event(const std::string &msg) {
       instance_->publish_feature_list();
     }
   }
+}
+
+std::string Roode::get_log_buffer() {
+  std::string out;
+  for (const auto &line : log_buffer_) {
+    out += line;
+    out += "\n";
+  }
+  return out;
 }
 
 Roode::~Roode() {
@@ -453,6 +467,18 @@ void Roode::register_server_endpoints() {
     request->send(200, "application/json", out.c_str());
   });
   server->addHandler(scan_session_handler);
+
+  auto *system_log_handler = new AsyncCallbackWebHandler();
+  system_log_handler->setUri("/api/system/logs");
+  system_log_handler->setMethod(HTTP_GET);
+  system_log_handler->onRequest([log_request](AsyncWebServerRequest *request) {
+    log_request(request);
+    if (!instance_->check_token_(request))
+      return;
+    std::string out = Roode::get_log_buffer();
+    request->send(200, "text/plain", out.c_str());
+  });
+  server->addHandler(system_log_handler);
 
   auto *scan_delete_handler = new AsyncCallbackWebHandler();
   scan_delete_handler->setUri("/api/scan/delete");
@@ -1330,6 +1356,27 @@ void Roode::start_passive_scan() {
           publish_scan_record("scan_cancel");
           scan_running = false;
           return;
+        }
+        if (presence_sensor != nullptr && presence_sensor->state) {
+          int retries = 0;
+          while (presence_sensor->state && retries < 10) {
+            ESP_LOGW(TAG, "Presence detected during scan, waiting...");
+            log_event("scan_wait_presence");
+            delay(500);
+            App.feed_wdt();
+            retries++;
+            if (scan_cancel_requested) {
+              publish_scan_record("scan_cancel");
+              scan_running = false;
+              return;
+            }
+          }
+          if (presence_sensor->state) {
+            ESP_LOGE(TAG, "Presence did not clear, aborting scan");
+            publish_scan_record("scan_presence_abort");
+            scan_running = false;
+            return;
+          }
         }
         std::vector<int> mcps(grid * grid, 0);
         std::vector<int> distance(grid * grid, 0);

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -175,14 +175,16 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   Zone *entry = new Zone(0);
   Zone *exit = new Zone(1);
   static void log_event(const std::string &msg);
+  static std::string get_log_buffer();
 
-  bool apply_recommended_settings();
+ bool apply_recommended_settings();
   void set_portal_password(const std::string &password) { portal_password_ = password; }
   void set_web_username(const std::string &username) { web_username_ = username; }
   void set_web_password(const std::string &password) { web_password_ = password; }
-  void set_web_portal_switch(switch_::Switch *sw) { portal_switch = sw; }
+ void set_web_portal_switch(switch_::Switch *sw) { portal_switch = sw; }
 
  protected:
+  static std::vector<std::string> log_buffer_;
   TofSensor *distanceSensor;
   Zone *current_zone = entry;
   sensor::Sensor *distance_entry{nullptr};


### PR DESCRIPTION
## Summary
- Retry passive calibration when presence is detected and abort if the area never clears
- Buffer recent log events and add `/api/system/logs` endpoint
- Portal log viewer now fetches system logs from the new endpoint

## Testing
- `platformio run -e roode` *(fails: esphome/components/number/number.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b685317b308330840bfd1979fd2ef3