### PR TITLE
Improve calibration logging and portal controls

### DIFF
--- a/components/roode/portal.h
+++ b/components/roode/portal.h
@@ -49,6 +49,8 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
     .right{margin-left:auto}
     .hr{height:1px;background:var(--line);margin:12px 0}
     .muted{color:var(--muted)}
+    #logBox{background:#0f1520;color:var(--text)}
+    @media (prefers-color-scheme: light){#logBox{background:#f6f8fa;color:var(--text)}}
   </style>
 </head>
 <body>
@@ -78,7 +80,9 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
         </div>
         <div class="hr"></div>
         <button class="btn" id="btnLog">Show Log</button>
-        <pre id="logBox" class="mono" style="display:none;max-height:200px;overflow:auto;background:#0f1520;border:1px solid var(--line);padding:8px;border-radius:8px;margin-top:8px"></pre>
+        <button class="btn" id="btnCopyLog" style="display:none">Copy Log</button>
+        <button class="btn" id="btnClearLog" style="display:none">Clear Log</button>
+        <pre id="logBox" class="mono" style="display:none;max-height:200px;overflow:auto;border:1px solid var(--line);padding:8px;border-radius:8px;margin-top:8px"></pre>
       </div>
 
       <!-- Current Settings -->
@@ -346,12 +350,16 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
           step: stat.running ? describeStep(stat.step) : '—',
           progress: stat.running ? (stat.progress || 0) * 100 : 0,
           remaining: stat.time_remaining,
-          last_calibration: stat.last_calibration
+          last_calibration: stat.last_calibration,
+          error: stat.error
         };
       } else {
-        status = {state:'Idle', id:status?.id || '—', step:'—', progress:0, remaining:0};
+        status = {state:'Idle', id:status?.id || '—', step:'—', progress:0, remaining:0, error:status?.error};
       }
-      if(wasScanning && status.state !== 'Scanning') showSuccess('Calibration complete');
+      if(wasScanning && status.state !== 'Scanning'){
+        if(status.error) showError(status.error);
+        else showSuccess('Calibration complete');
+      }
       if(list) sessions = list.sessions || list;
       preview = prev || null;
 
@@ -369,7 +377,7 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
     try {
       const r = await postJSON('/api/scan/start');
       const id = r && (r.id || r.session_id);
-      if(id){ status = {state:'Scanning', id, step:'4×4 Scan', progress:0, remaining:0}; renderStatus(); }
+      if(id){ status = {state:'Scanning', id, step:'4×4 Scan', progress:0, remaining:0, error:null}; renderStatus(); }
     } finally {
       btn.disabled = false;
     }
@@ -379,8 +387,9 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
     btn.disabled = true;
     try {
       await postJSON('/api/scan/cancel');
-      status = {state:'Idle', id:status?.id || '—', step:'—', progress:0, remaining:0};
+      status = {state:'Idle', id:status?.id || '—', step:'—', progress:0, remaining:0, error:'Scan cancelled'};
       renderStatus();
+      showError('Scan cancelled');
     } finally {
       btn.disabled = false;
     }
@@ -389,7 +398,16 @@ inline const char portal_html[] PROGMEM = R"PORTAL(
     logVisible = !logVisible;
     $('#logBox').style.display = logVisible ? 'block' : 'none';
     $('#btnLog').textContent = logVisible ? 'Hide Log' : 'Show Log';
+    $('#btnCopyLog').style.display = logVisible ? 'inline-block' : 'none';
+    $('#btnClearLog').style.display = logVisible ? 'inline-block' : 'none';
     if(logVisible) await fetchLog();
+  });
+  $('#btnCopyLog').addEventListener('click', ()=>{
+    const txt = $('#logBox').textContent;
+    navigator.clipboard.writeText(txt);
+  });
+  $('#btnClearLog').addEventListener('click', ()=>{
+    $('#logBox').textContent = '';
   });
   $('#btnApply').addEventListener('click', async (e)=>{
     const btn = e.target;

--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -270,6 +270,7 @@ void Roode::register_server_endpoints() {
     doc["session_id"] = scan_session_id_.c_str();
     doc["step"] = scan_step_;
     doc["progress"] = scan_progress_;
+    doc["error"] = scan_error_msg_.c_str();
     double elapsed = scan_running ? (millis() - scan_start_ts_) / 1000.0 : 0.0;
     double remaining = (scan_running && scan_progress_ > 0.0f && scan_progress_ < 1.0f)
                            ? elapsed * (1.0 - scan_progress_) / scan_progress_
@@ -293,6 +294,7 @@ void Roode::register_server_endpoints() {
     DynamicJsonDocument doc(128);
     if (!scan_running) {
       scan_cancel_requested = false;
+      scan_error_msg_.clear();
       // Prepare a session id and launch the potentially long running scan in
       // its own task so that the web server can continue to serve status
       // updates.
@@ -1316,6 +1318,7 @@ void Roode::start_passive_scan() {
   scan_step_ = 0;
   scan_total_steps_ = grids.size() * (sizeof(modes) / sizeof(modes[0])) * max_trials;
   scan_progress_ = 0.0f;
+  scan_error_msg_.clear();
   recommended_settings_.reset();
   struct ScanGroup {
     int grid;
@@ -1327,6 +1330,7 @@ void Roode::start_passive_scan() {
   for (int grid : grids) {
     if (scan_cancel_requested) {
       publish_scan_record("scan_cancel");
+      scan_error_msg_ = "Scan cancelled";
       scan_running = false;
       return;
     }
@@ -1340,6 +1344,7 @@ void Roode::start_passive_scan() {
     for (const char *mode : modes) {
       if (scan_cancel_requested) {
         publish_scan_record("scan_cancel");
+        scan_error_msg_ = "Scan cancelled";
         scan_running = false;
         return;
       }
@@ -1354,6 +1359,7 @@ void Roode::start_passive_scan() {
       for (int trial = 1; trial <= max_trials; ++trial) {
         if (scan_cancel_requested) {
           publish_scan_record("scan_cancel");
+          scan_error_msg_ = "Scan cancelled";
           scan_running = false;
           return;
         }
@@ -1367,15 +1373,16 @@ void Roode::start_passive_scan() {
             retries++;
             if (scan_cancel_requested) {
               publish_scan_record("scan_cancel");
+              scan_error_msg_ = "Scan cancelled";
               scan_running = false;
               return;
             }
           }
           if (presence_sensor->state) {
-            ESP_LOGE(TAG, "Presence did not clear, aborting scan");
-            publish_scan_record("scan_presence_abort");
-            scan_running = false;
-            return;
+            ESP_LOGW(TAG, "Presence did not clear, forcing reset");
+            log_event("scan_presence_force_clear");
+            publish_scan_record("scan_presence_force_clear");
+            presence_sensor->publish_state(false);
           }
         }
         std::vector<int> mcps(grid * grid, 0);

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -258,6 +258,7 @@ class Roode : public PollingComponent, public api::CustomAPIDevice {
   int scan_step_{0};
   int scan_total_steps_{0};
   float scan_progress_{0.0f};
+  std::string scan_error_msg_{};
   std::optional<RecommendedSettings> recommended_settings_{};
   float trial_bump_cv_{20.0f};
   float scan_time_cap_seconds_{90.0f};


### PR DESCRIPTION
## Summary
- Track and expose scan errors via `/api/scan/status`
- Prevent false aborts by forcing presence reset and logging the reason
- Enhance portal log viewer with better contrast plus copy and clear controls

## Testing
- `clang-format -i components/roode/roode.cpp components/roode/roode.h components/roode/portal.h` *(fails: command not found)*
- `platformio run -e roode` *(fails: esphome headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e89f9aa88330ba87507abcdd3a5a