### PR TITLE
Tolerate read failures during calibration

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -965,7 +965,8 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
   // Preserve previous calibration data in case calibration fails
   CalibrationPrefs prev_cal = calibration_data_[zone_id];
 
-  bool calibrated = z->calibrateThreshold(distanceSensor, 50);
+  int error_count = 0;
+  bool calibrated = z->calibrateThreshold(distanceSensor, 50, &error_count);
   if (!calibrated) {
     ESP_LOGE(CALIBRATION, "Calibration failed for zone %d. Restoring previous settings.", zone_id);
     log_event(std::string("zone_") + std::to_string(zone_id) + "_calibration_failed");
@@ -976,6 +977,11 @@ void Roode::run_zone_calibration(uint8_t zone_id) {
       status_sensor->publish_state(-1);
     update_status_text("calibration_failed");
     return;
+  }
+
+  if (error_count > 0) {
+    ESP_LOGW(CALIBRATION, "Zone %d calibration completed with %d errors", zone_id, error_count);
+    log_event(std::string("zone_") + std::to_string(zone_id) + "_calibration_errors_" + std::to_string(error_count));
   }
 
   // Recalculate ROI sizes so thresholds remain consistent

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -71,14 +71,14 @@ void Zone::reset_roi(uint8_t default_center) {
   roi->center = roi_override->center ?: default_center;
 }
 
-bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
+bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts, int *error_count) {
   // Preserve previous thresholds in case calibration fails
   Threshold previous = *threshold;
 
   std::vector<int> zone_distances;
   zone_distances.reserve(number_attempts);
   int sum = 0;
-  bool read_failed = false;
+  int errors = 0;
 
   for (int i = 0; i < number_attempts; i++) {
     bool success = false;
@@ -89,16 +89,17 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
         break;
       }
       // log and delay before retrying to give the sensor time to recover
-      ESP_LOGW(CALIBRATION,
-               "Distance read failed during calibration. status: %d (retry %d)",
-               sensor_status, retry + 1);
+      ESP_LOGW(CALIBRATION, "Distance read failed during calibration. status: %d (retry %d)", sensor_status, retry + 1);
       Roode::log_event("calibration_read_retry");
       delay(50);
       App.feed_wdt();
     }
     if (!success) {
-      read_failed = true;
-      break;
+      errors++;
+      ESP_LOGW(CALIBRATION, "Distance read failed during calibration. marking attempt %d bad", i + 1);
+      Roode::log_event("calibration_read_fail");
+      // continue to next attempt without adding a distance
+      continue;
     }
 
     zone_distances.push_back(this->getDistance());
@@ -108,7 +109,10 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
     App.feed_wdt();
   }
 
-  if (zone_distances.empty() || read_failed) {
+  if (error_count != nullptr)
+    *error_count = errors;
+
+  if (zone_distances.empty()) {
     *threshold = previous;
     distanceSensor->restart();
     ESP_LOGW(CALIBRATION, "Calibration failed: no valid distances recorded");
@@ -129,6 +133,12 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
            threshold->idle, threshold->min,
            threshold->min_percentage.value_or((threshold->min * 100) / threshold->idle), threshold->max,
            threshold->max_percentage.value_or((threshold->max * 100) / threshold->idle));
+
+  if (errors > 0) {
+    ESP_LOGW(CALIBRATION, "Calibration finished with %d errors for zone %d", errors, id);
+    Roode::log_event("calibration_finished_with_errors");
+  }
+
   return true;
 }
 

--- a/components/roode/zone.h
+++ b/components/roode/zone.h
@@ -38,10 +38,14 @@ class Zone {
   VL53L1_Error readDistance(TofSensor *distanceSensor);
   void reset_roi(uint8_t default_center);
   /**
-   * Calibrate the zone's distance thresholds. Returns true when at least one
-   * valid distance measurement is recorded.
+   * Calibrate the zone's distance thresholds.
+   *
+   * The calibration will attempt the given number of reads and tolerate
+   * individual failures. When at least one valid distance measurement is
+   * recorded the calibration succeeds, even if some reads fail. The number of
+   * failed reads is returned via @p error_count when provided.
    */
-  bool calibrateThreshold(TofSensor *distanceSensor, int number_attempts);
+  bool calibrateThreshold(TofSensor *distanceSensor, int number_attempts, int *error_count = nullptr);
   void roi_calibration(uint16_t entry_threshold, uint16_t exit_threshold, Orientation orientation);
   void set_threshold_percentages(uint8_t min_percent, uint8_t max_percent);
   const uint8_t id;


### PR DESCRIPTION
## Summary
- allow `calibrateThreshold` to continue despite individual distance read failures and track error count
- report zone calibration errors without aborting the process

## Testing
- `pio run -e roode` *(fails: esphome/components/number/number.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b6ef6c6c248330ab7e83b356681596