### PR TITLE
Reset VL53L1X before reinitializing post-calibration

### DIFF
--- a/calibration/OffsetAndXtalkCalibration/OffsetAndXtalkCalibration.ino
+++ b/calibration/OffsetAndXtalkCalibration/OffsetAndXtalkCalibration.ino
@@ -72,6 +72,10 @@ void setup()
     {
         Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
     }
+    sensor.ClearInterrupt();
+    sensor.StopRanging();
+    sensor.Init();
+    sensor.StartRanging();
 }
 void loop()
 {

--- a/calibration/src/OffsetAndXtalkCalibration.cpp
+++ b/calibration/src/OffsetAndXtalkCalibration.cpp
@@ -72,6 +72,9 @@ void setup()
     {
         Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
     }
+    sensor.ClearInterrupt();
+    sensor.StopRanging();
+    sensor.Init();
     sensor.StartRanging();
 }
 void loop()


### PR DESCRIPTION
## Summary
- Clear interrupts and stop ranging before reinitializing the VL53L1X after calibration
- Start ranging again so measurements resume from a clean state

## Testing
- ⚠️ `pio run -e roode` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7902b083c8330a1df538893c00c20