### PR TITLE
Poll VL53L1X readiness in calibration loop

### DIFF
--- a/calibration/src/OffsetAndXtalkCalibration.cpp
+++ b/calibration/src/OffsetAndXtalkCalibration.cpp
@@ -1,7 +1,7 @@
 #include "VL53L1X_ULD.h"
 
 VL53L1X_ULD sensor;
-bool dataReady;
+uint8_t dataReady;
 
 void setup()
 {
@@ -76,6 +76,7 @@ void setup()
 }
 void loop()
 {
+    sensor.CheckForDataReady(&dataReady);
     if (dataReady)
     {
         // Get the results
@@ -87,5 +88,9 @@ void loop()
         dataReady = false;
 
         Serial.println("Distance in mm: " + String(distance));
+    }
+    else
+    {
+        delay(1); // Small delay to avoid busy-waiting
     }
 }


### PR DESCRIPTION
## Summary
- poll VL53L1X for data-ready flag in calibration example
- add small delay to avoid busy-waiting when data is not ready

## Testing
- `cd calibration && pio run`

------
https://chatgpt.com/codex/tasks/task_e_68b7902878e08330bcdf3b19988815c2