### PR TITLE
Add calibration distance range checks

### DIFF
--- a/calibration/OffsetAndXtalkCalibration/OffsetAndXtalkCalibration.ino
+++ b/calibration/OffsetAndXtalkCalibration/OffsetAndXtalkCalibration.ino
@@ -35,25 +35,36 @@ void setup() {
   Serial.println("The calibration may take a few seconds. The offset correction is applied to the sensor at the end of "
                  "calibration.");
   Serial.readString();
+
+  constexpr uint16_t MIN_DISTANCE_MM = 40;
+  constexpr uint16_t MAX_DISTANCE_MM = 4000;
+  const uint16_t offset_distance = 140;  // distance used for offset calibration
   int16_t foundOffset;
-  sensor_status = sensor.CalibrateOffset(140, &foundOffset);
-  if (sensor_status != VL53L1_ERROR_NONE) {
-    Serial.printf("Offset calibration failed, error code: %d\n", sensor_status);
-    if (!recoverSensor()) {
-      Serial.println("Recovery failed, aborting calibration.");
-      return;
-    }
+
+  if (offset_distance < MIN_DISTANCE_MM || offset_distance > MAX_DISTANCE_MM) {
+    Serial.printf(
+        "Offset calibration distance %dmm out of range (%d-%d). Skipping offset calibration.\n",
+        offset_distance, MIN_DISTANCE_MM, MAX_DISTANCE_MM);
   } else {
-    Serial.println("Calibrated offset: " + String(foundOffset));
-    sensor_status = sensor.SetOffsetInMm(foundOffset);
+    sensor_status = sensor.CalibrateOffset(offset_distance, &foundOffset);
     if (sensor_status != VL53L1_ERROR_NONE) {
-      Serial.printf("Failed to set offset, error code: %d\n", sensor_status);
+      Serial.printf("Offset calibration failed, error code: %d\n", sensor_status);
       if (!recoverSensor()) {
         Serial.println("Recovery failed, aborting calibration.");
         return;
       }
     } else {
-      Serial.printf("Offset %d set and active\n", foundOffset);
+      Serial.println("Calibrated offset: " + String(foundOffset));
+      sensor_status = sensor.SetOffsetInMm(foundOffset);
+      if (sensor_status != VL53L1_ERROR_NONE) {
+        Serial.printf("Failed to set offset, error code: %d\n", sensor_status);
+        if (!recoverSensor()) {
+          Serial.println("Recovery failed, aborting calibration.");
+          return;
+        }
+      } else {
+        Serial.printf("Offset %d set and active\n", foundOffset);
+      }
     }
   }
 
@@ -69,24 +80,31 @@ void setup() {
   */
   uint16_t CalibrationDistance = 140;  // crosstalk calibration distance
   uint16_t foundXTalk;
-  sensor_status = sensor.CalibrateXTalk(CalibrationDistance, &foundXTalk);
-  if (sensor_status != VL53L1_ERROR_NONE) {
-    Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
-    if (!recoverSensor()) {
-      Serial.println("Recovery failed, aborting calibration.");
-      return;
-    }
+
+  if (CalibrationDistance < MIN_DISTANCE_MM || CalibrationDistance > MAX_DISTANCE_MM) {
+    Serial.printf(
+        "Crosstalk calibration distance %dmm out of range (%d-%d). Skipping crosstalk calibration.\n",
+        CalibrationDistance, MIN_DISTANCE_MM, MAX_DISTANCE_MM);
   } else {
-    Serial.println("Calibrated crosstalk: " + String(foundXTalk));
-    sensor_status = sensor.SetXTalk(foundXTalk);
+    sensor_status = sensor.CalibrateXTalk(CalibrationDistance, &foundXTalk);
     if (sensor_status != VL53L1_ERROR_NONE) {
-      Serial.printf("Failed to set crosstalk, error code: %d\n", sensor_status);
+      Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
       if (!recoverSensor()) {
         Serial.println("Recovery failed, aborting calibration.");
         return;
       }
     } else {
-      Serial.printf("Crosstalk %d set and active\n", foundXTalk);
+      Serial.println("Calibrated crosstalk: " + String(foundXTalk));
+      sensor_status = sensor.SetXTalk(foundXTalk);
+      if (sensor_status != VL53L1_ERROR_NONE) {
+        Serial.printf("Failed to set crosstalk, error code: %d\n", sensor_status);
+        if (!recoverSensor()) {
+          Serial.println("Recovery failed, aborting calibration.");
+          return;
+        }
+      } else {
+        Serial.printf("Crosstalk %d set and active\n", foundXTalk);
+      }
     }
   }
   sensor.ClearInterrupt();

--- a/calibration/src/OffsetAndXtalkCalibration.cpp
+++ b/calibration/src/OffsetAndXtalkCalibration.cpp
@@ -42,25 +42,36 @@ void setup() {
   while (Serial.available()) {
     Serial.read();  // Clear any received data
   }
+
+  constexpr uint16_t MIN_DISTANCE_MM = 40;
+  constexpr uint16_t MAX_DISTANCE_MM = 4000;
+  const uint16_t offset_distance = 140;  // distance used for offset calibration
   int16_t foundOffset;
-  sensor_status = sensor.CalibrateOffset(140, &foundOffset);
-  if (sensor_status != VL53L1_ERROR_NONE) {
-    Serial.printf("Offset calibration failed, error code: %d\n", sensor_status);
-    if (!recoverSensor()) {
-      Serial.println("Recovery failed, aborting calibration.");
-      return;
-    }
+
+  if (offset_distance < MIN_DISTANCE_MM || offset_distance > MAX_DISTANCE_MM) {
+    Serial.printf(
+        "Offset calibration distance %dmm out of range (%d-%d). Skipping offset calibration.\n",
+        offset_distance, MIN_DISTANCE_MM, MAX_DISTANCE_MM);
   } else {
-    Serial.println("Calibrated offset: " + String(foundOffset));
-    sensor_status = sensor.SetOffsetInMm(foundOffset);
+    sensor_status = sensor.CalibrateOffset(offset_distance, &foundOffset);
     if (sensor_status != VL53L1_ERROR_NONE) {
-      Serial.printf("Failed to set offset, error code: %d\n", sensor_status);
+      Serial.printf("Offset calibration failed, error code: %d\n", sensor_status);
       if (!recoverSensor()) {
         Serial.println("Recovery failed, aborting calibration.");
         return;
       }
     } else {
-      Serial.printf("Offset %d set and active\n", foundOffset);
+      Serial.println("Calibrated offset: " + String(foundOffset));
+      sensor_status = sensor.SetOffsetInMm(foundOffset);
+      if (sensor_status != VL53L1_ERROR_NONE) {
+        Serial.printf("Failed to set offset, error code: %d\n", sensor_status);
+        if (!recoverSensor()) {
+          Serial.println("Recovery failed, aborting calibration.");
+          return;
+        }
+      } else {
+        Serial.printf("Offset %d set and active\n", foundOffset);
+      }
     }
   }
 
@@ -76,24 +87,31 @@ void setup() {
   */
   uint16_t CalibrationDistance = 140;  // crosstalk calibration distance
   uint16_t foundXTalk;
-  sensor_status = sensor.CalibrateXTalk(CalibrationDistance, &foundXTalk);
-  if (sensor_status != VL53L1_ERROR_NONE) {
-    Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
-    if (!recoverSensor()) {
-      Serial.println("Recovery failed, aborting calibration.");
-      return;
-    }
+
+  if (CalibrationDistance < MIN_DISTANCE_MM || CalibrationDistance > MAX_DISTANCE_MM) {
+    Serial.printf(
+        "Crosstalk calibration distance %dmm out of range (%d-%d). Skipping crosstalk calibration.\n",
+        CalibrationDistance, MIN_DISTANCE_MM, MAX_DISTANCE_MM);
   } else {
-    Serial.println("Calibrated crosstalk: " + String(foundXTalk));
-    sensor_status = sensor.SetXTalk(foundXTalk);
+    sensor_status = sensor.CalibrateXTalk(CalibrationDistance, &foundXTalk);
     if (sensor_status != VL53L1_ERROR_NONE) {
-      Serial.printf("Failed to set crosstalk, error code: %d\n", sensor_status);
+      Serial.printf("Crosstalk calibration failed, error code: %d\n", sensor_status);
       if (!recoverSensor()) {
         Serial.println("Recovery failed, aborting calibration.");
         return;
       }
     } else {
-      Serial.printf("Crosstalk %d set and active\n", foundXTalk);
+      Serial.println("Calibrated crosstalk: " + String(foundXTalk));
+      sensor_status = sensor.SetXTalk(foundXTalk);
+      if (sensor_status != VL53L1_ERROR_NONE) {
+        Serial.printf("Failed to set crosstalk, error code: %d\n", sensor_status);
+        if (!recoverSensor()) {
+          Serial.println("Recovery failed, aborting calibration.");
+          return;
+        }
+      } else {
+        Serial.printf("Crosstalk %d set and active\n", foundXTalk);
+      }
     }
   }
   sensor.ClearInterrupt();


### PR DESCRIPTION
## Summary
- add range validation for offset and crosstalk calibration distances in calibration setup
- skip calibrations when specified distances exceed sensor range

## Testing
- `pio run -e roode` *(fails: esphome/components/number/number.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b7902c559c83308a77cb87694e3d52