### PR TITLE
Clarify sensor pin comments in dev configs

### DIFF
--- a/peopleCounter32Dev.yaml
+++ b/peopleCounter32Dev.yaml
@@ -58,7 +58,7 @@ vl53l1x:
     # ranging: longest # defaults to "auto" for formerly "calibration: true"
     # offset: 8
     # xtalk: 53406
-  # These pins are not yet implemented but they are passed into class now
+  # Configure XSHUT and interrupt pins for the sensor
   pins:
     xshut:
       number: GPIO3

--- a/peopleCounter8266Dev.yaml
+++ b/peopleCounter8266Dev.yaml
@@ -54,7 +54,7 @@ vl53l1x:
     # ranging: longest # defaults to "auto" for formerly "calibration: true"
     # offset: 8
     # xtalk: 53406
-  # These pins are not yet implemented but they are passed into class now
+  # Configure XSHUT and interrupt pins for the sensor
   pins:
     xshut:
       number: GPIO3


### PR DESCRIPTION
## Summary
- clarify VL53L1X pin comments in ESP32 and ESP8266 dev configs

## Testing
- `esphome config peopleCounter32Dev.yaml` *(fails: Unknown pin mode OUTPUT_PULLUP)*
- `esphome config peopleCounter8266Dev.yaml` *(fails: Please remove the `platform` key from the [esphome] block and use the correct platform component)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a0980e1083308f67a9ea4a045f42