### PR TITLE
Handle sensor resets during calibration

### DIFF
--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -74,6 +74,7 @@ void Zone::reset_roi(uint8_t default_center) {
 bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts, int *error_count) {
   // Preserve previous thresholds in case calibration fails
   Threshold previous = *threshold;
+  constexpr uint32_t SENSOR_BOOT_DELAY_MS = 100;
 
   // Ensure the sensor has completed booting before starting calibration
   VL53L1_Error status = distanceSensor->wait_for_boot();
@@ -84,7 +85,7 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts, in
       *error_count = number_attempts;
     return false;
   }
-  delay(100);
+  delay(SENSOR_BOOT_DELAY_MS);
   App.feed_wdt();
 
   std::vector<int> zone_distances;
@@ -108,7 +109,7 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts, in
       reset_count++;
       distanceSensor->init();
       distanceSensor->wait_for_boot();
-      delay(100);
+      delay(SENSOR_BOOT_DELAY_MS);
       App.feed_wdt();
       if (reset_count >= MAX_SENSOR_RESETS) {
         ESP_LOGE(CALIBRATION, "Calibration aborted after %d sensor resets", reset_count);

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -75,10 +75,24 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts, in
   // Preserve previous thresholds in case calibration fails
   Threshold previous = *threshold;
 
+  // Ensure the sensor has completed booting before starting calibration
+  VL53L1_Error status = distanceSensor->wait_for_boot();
+  if (status != VL53L1_ERROR_NONE) {
+    ESP_LOGW(CALIBRATION, "Sensor not ready for calibration. status: %d", status);
+    Roode::log_event("calibration_boot_failed");
+    if (error_count != nullptr)
+      *error_count = number_attempts;
+    return false;
+  }
+  delay(100);
+  App.feed_wdt();
+
   std::vector<int> zone_distances;
   zone_distances.reserve(number_attempts);
   int sum = 0;
   int errors = 0;
+  int reset_count = 0;
+  constexpr int MAX_SENSOR_RESETS = 3;
 
   for (int i = 0; i < number_attempts; i++) {
     bool success = false;
@@ -88,11 +102,23 @@ bool Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts, in
         success = true;
         break;
       }
-      // log and delay before retrying to give the sensor time to recover
+      // log, attempt to reinitialize the sensor, and delay before retrying
       ESP_LOGW(CALIBRATION, "Distance read failed during calibration. status: %d (retry %d)", sensor_status, retry + 1);
       Roode::log_event("calibration_read_retry");
-      delay(50);
+      reset_count++;
+      distanceSensor->init();
+      distanceSensor->wait_for_boot();
+      delay(100);
       App.feed_wdt();
+      if (reset_count >= MAX_SENSOR_RESETS) {
+        ESP_LOGE(CALIBRATION, "Calibration aborted after %d sensor resets", reset_count);
+        Roode::log_event("calibration_reset_limit");
+        if (error_count != nullptr)
+          *error_count = errors + (number_attempts - i);
+        *threshold = previous;
+        distanceSensor->restart();
+        return false;
+      }
     }
     if (!success) {
       errors++;

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -47,6 +47,8 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   void set_sensor_id(uint8_t id) { sensor_id_ = id; }
   void set_desired_address(uint8_t addr) { desired_address_ = addr; }
   void restart();
+  VL53L1_Error init();
+  VL53L1_Error wait_for_boot();
 
   void set_xshut_pin(GPIOPin *pin) { this->xshut_pin = pin; }
   void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin = pin; }
@@ -62,7 +64,7 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   VL53L1X_ULD sensor;
   optional<GPIOPin *> xshut_pin{};
   optional<InternalGPIOPin *> interrupt_pin{};
-  const RangingMode * ranging_mode{};
+  const RangingMode *ranging_mode{};
   /** Mode from user config, which can be get/set independently of current mode */
   optional<const RangingMode *> ranging_mode_override{};
   optional<int16_t> offset{};
@@ -74,8 +76,6 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   uint8_t desired_address_{0x29};
   static std::vector<VL53L1X *> sensors;
 
-  VL53L1_Error init();
-  VL53L1_Error wait_for_boot();
   VL53L1_Error get_device_state(uint8_t *device_state);
   /**
    * Validate optional pins and log their status.
@@ -96,4 +96,3 @@ class VL53L1X : public i2c::I2CDevice, public Component {
 
 }  // namespace vl53l1x
 }  // namespace esphome
-


### PR DESCRIPTION
## Summary
- wait for VL53L1X boot before starting zone calibration
- reinitialize sensor on read errors and abort after repeated resets
- expose VL53L1X init and boot helpers for calibration recovery

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b7984a88848330b101018ab203e8d9