### PR TITLE
Fix people detection, build error, and portal issues

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -102,6 +102,21 @@ void Roode::setup() {
     }
     entry->set_debug_mode(debug_mode_); exit->set_debug_mode(debug_mode_);
   }
+  // Auto-calibrate on first boot when thresholds are zero (no saved calibration data)
+  if (distanceSensor && (entry->threshold->max == 0 || exit->threshold->max == 0)) {
+    ESP_LOGI(TAG, "No calibration data found - running initial threshold calibration");
+    recalibration();
+    // Persist calibration results to flash so subsequent boots skip this step
+    RoodeSettings cal_s;
+    if (!settings_prefs_.load(&cal_s)) memset(&cal_s, 0, sizeof(cal_s));
+    cal_s.entry_min_threshold = entry->threshold->min;
+    cal_s.entry_max_threshold = entry->threshold->max;
+    cal_s.exit_min_threshold = exit->threshold->min;
+    cal_s.exit_max_threshold = exit->threshold->max;
+    settings_prefs_.save(&cal_s);
+    global_preferences->sync();
+  }
+
 #ifdef CONFIG_IDF_TARGET_ESP32
   if (!force_single_core_) {
     xTaskCreatePinnedToCore(sensor_task, "SensorTask", 4096, this, 1, &sensor_task_handle_, 1);
@@ -182,6 +197,10 @@ void Roode::register_portal_routes_() {
   base->add_handler_without_auth(new LambdaRequestHandler(HTTP_GET, "/api/scan/status", [this](roode_web::AsyncWebServerRequest *r) {
     JsonDocument d; d["s"] = scan_state_ == SCANNING ? "Scanning" : "Idle"; d["p"] = scan_progress_;
     std::string out; serializeJson(d, out); r->send(200, "application/json", out.c_str());
+  }));
+  base->add_handler_without_auth(new LambdaRequestHandler(HTTP_POST, "/api/scan/cancel", [this](roode_web::AsyncWebServerRequest *r) {
+    scan_state_ = SCAN_IDLE; scan_progress_ = 0;
+    r->send(200, "application/json", "{\"ok\":true}");
   }));
   base->add_handler_without_auth(new LambdaRequestHandler(HTTP_GET, "/api/scan/sessions", [this](roode_web::AsyncWebServerRequest *r) {
     if (!require_portal_auth_(r, "application/json")) return;

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -104,6 +104,7 @@ class Roode;
 class PortalSwitch : public switch_::Switch, public Component {
  public:
   void set_parent(Roode *parent) { parent_ = parent; }
+  void setup() override;
   void write_state(bool state) override;
   void dump_config() override;
  protected:
@@ -194,6 +195,8 @@ class Roode : public PollingComponent {
   void set_force_single_core(bool val) { force_single_core_ = val; }
   void set_auto_calibration_interval_sec(uint32_t sec) { auto_calibration_interval_sec_ = sec; }
   void set_manual_presence(bool val) { manual_presence_ = val; }
+  void set_active_sensors(uint32_t mask) { active_sensors_ = mask; }
+  bool is_portal_enabled() const { return portal_enabled_; }
 
   void run_zone_calibration(uint8_t zone_id);
   void recalibration();

--- a/components/roode/roode_portal.h
+++ b/components/roode/roode_portal.h
@@ -281,21 +281,24 @@ static const char *const portal_html = R"PORTAL(
   $('#btnCancel').onclick = () => api('/api/scan/cancel', 'POST');
   $('#btnApply').onclick = () => api('/api/roi/apply', 'POST').then(()=>alert('Applied'));
   
+  function boolStr(v){ return v ? 'true' : 'false'; }
   $('#btnSaveSettings').onclick = () => {
-    const body = {
+    const params = new URLSearchParams({
       sa: parseInt($('#setSampling').value), or: parseInt($('#setOrientation').value),
-      inv: $('#setInvert').checked, cp: $('#setPersist').checked,
+      inv: boolStr($('#setInvert').checked), cp: boolStr($('#setPersist').checked),
       fm: parseInt($('#setFilterMode').value), fw: parseInt($('#setFilterWindow').value),
-      ul: $('#setUseLux').checked, us: $('#setUseSun').checked,
-      sid: parseInt($('#setSid').value), addr: parseInt($('#setAddr').value, 16),
-      to: parseInt($('#setTO').value), rm: parseInt($('#setRM').value)
-    };
-    api('/api/settings/update', 'POST', body).then(r => r && alert('Settings Updated'));
+      ul: boolStr($('#setUseLux').checked), us: boolStr($('#setUseSun').checked),
+      sid: parseInt($('#setSid').value), to: parseInt($('#setTO').value),
+      rm: parseInt($('#setRM').value),
+      debug: boolStr($('#setDebug').checked), sc: boolStr($('#setSingleCore').checked),
+      il: parseInt($('#setInvalidLimit').value), rt: parseInt($('#setRestartTO').value)
+    }).toString();
+    api('/api/settings/update?' + params, 'POST').then(r => r && alert('Settings Updated'));
   };
 
   $('#btnSaveSensors').onclick = () => {
     let m = 0; document.querySelectorAll('.sensor-opt').forEach(el => { if(el.checked) m |= parseInt(el.dataset.id); });
-    api('/api/settings/update', 'POST', {m}).then(r => r && alert('Visibility Updated'));
+    api('/api/settings/update?m=' + m, 'POST').then(r => r && alert('Visibility Updated'));
   };
 
   setInterval(poll, 2000); poll();

--- a/components/roode/switch.cpp
+++ b/components/roode/switch.cpp
@@ -4,6 +4,12 @@
 namespace esphome {
 namespace roode {
 
+void PortalSwitch::setup() {
+  if (parent_ != nullptr) {
+    this->publish_state(parent_->is_portal_enabled());
+  }
+}
+
 void PortalSwitch::write_state(bool state) {
   this->publish_state(state);
   if (parent_ != nullptr) {

--- a/components/roode/zone.cpp
+++ b/components/roode/zone.cpp
@@ -110,10 +110,12 @@ void Zone::calibrateThreshold(TofSensor *distanceSensor, int number_attempts) {
       sum += dist;
     }
   };
-  if (zone_distances.size() < (size_t) number_attempts) {
+  // Require at least 70% valid readings (or minimum 10) to proceed with calibration
+  size_t min_valid = std::max((size_t)10, (size_t)(number_attempts * 7 / 10));
+  if (zone_distances.size() < min_valid) {
     if (debug_mode_) {
       ESP_LOGW(CALIBRATION, "Calibration failed: only %d valid distances recorded (needed %d). Retaining previous baseline.",
-               zone_distances.size(), number_attempts);
+               zone_distances.size(), min_valid);
     }
   } else {
     int avg = sum / zone_distances.size();


### PR DESCRIPTION
- Add missing set_active_sensors() to fix compile error
- Auto-calibrate thresholds on first boot so detection works without manual calibration; persist results to flash
- Relax calibration to require 70% valid readings instead of 100%, preventing silent failures on noisy sensor readings
- Add PortalSwitch::setup() to publish initial state to Home Assistant
- Fix portal settings save: send URL params instead of JSON body so the C++ backend can read them; add missing diagnostics fields
- Add /api/scan/cancel endpoint so the portal cancel button works