### PR TITLE
Fix ROI initialization, sensor detection, and portal settings

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -80,21 +80,28 @@ void Roode::setup() {
   if (!i2c_mutex_) i2c_mutex_ = xSemaphoreCreateRecursiveMutex();
 #endif
   settings_prefs_ = global_preferences->make_preference<RoodeSettings>(0xB0);
+  bool loaded_from_flash = false;
   RoodeSettings s; if (settings_prefs_.load(&s)) {
+    loaded_from_flash = true;
     samples = s.sampling; orientation_ = s.orientation; invert_direction_ = s.invert_direction;
     calibration_persistence_ = s.calibration_persistence; filter_mode_ = s.filter_mode; filter_window_ = s.filter_window;
     log_fallback_events_ = s.log_fallback_events; force_single_core_ = s.force_single_core;
     invalid_distance_limit_ = s.invalid_limit; restart_timeout_ms_ = s.restart_timeout;
     cpu_opt_activate_threshold_ = s.cpu_activate; cpu_opt_deactivate_threshold_ = s.cpu_deactivate;
     active_sensors_ = s.active_sensors; debug_mode_ = s.debug_mode;
-    
-    entry->roi->height = s.entry_roi_height; entry->roi->width = s.entry_roi_width; entry->roi->center = s.entry_roi_center;
+
+    // Only load ROI from flash if it has valid non-zero values
+    if (s.entry_roi_height > 0 && s.entry_roi_width > 0) {
+      entry->roi->height = s.entry_roi_height; entry->roi->width = s.entry_roi_width; entry->roi->center = s.entry_roi_center;
+    }
+    if (s.exit_roi_height > 0 && s.exit_roi_width > 0) {
+      exit->roi->height = s.exit_roi_height; exit->roi->width = s.exit_roi_width; exit->roi->center = s.exit_roi_center;
+    }
     entry->threshold->min = s.entry_min_threshold; entry->threshold->max = s.entry_max_threshold;
-    exit->roi->height = s.exit_roi_height; exit->roi->width = s.exit_roi_width; exit->roi->center = s.exit_roi_center;
     exit->threshold->min = s.exit_min_threshold; exit->threshold->max = s.exit_max_threshold;
-    
+
     use_lux_ = s.use_lux; use_sun_ = s.use_sun;
-    
+
     if (distanceSensor) {
       if (s.sensor_id > 0) distanceSensor->set_sensor_id(s.sensor_id);
       if (s.timeout > 0) distanceSensor->set_timeout(s.timeout);
@@ -102,17 +109,28 @@ void Roode::setup() {
     }
     entry->set_debug_mode(debug_mode_); exit->set_debug_mode(debug_mode_);
   }
+
+  // Apply YAML roi_override → roi for any zone whose roi is still zero (not loaded from flash).
+  // This is the fix for the critical bug: roi starts as {0,0,0} and reset_roi() was never called,
+  // causing every sensor.SetROI(0,0) to fail and return no valid readings.
+  if (entry->roi->width == 0 || entry->roi->height == 0) {
+    entry->reset_roi(orientation_ == Parallel ? 159 : 194);
+  }
+  if (exit->roi->width == 0 || exit->roi->height == 0) {
+    exit->reset_roi(orientation_ == Parallel ? 239 : 59);
+  }
+
   // Auto-calibrate on first boot when thresholds are zero (no saved calibration data)
   if (distanceSensor && (entry->threshold->max == 0 || exit->threshold->max == 0)) {
     ESP_LOGI(TAG, "No calibration data found - running initial threshold calibration");
     recalibration();
-    // Persist calibration results to flash so subsequent boots skip this step
+    // Persist calibration results + current ROI to flash
     RoodeSettings cal_s;
     if (!settings_prefs_.load(&cal_s)) memset(&cal_s, 0, sizeof(cal_s));
-    cal_s.entry_min_threshold = entry->threshold->min;
-    cal_s.entry_max_threshold = entry->threshold->max;
-    cal_s.exit_min_threshold = exit->threshold->min;
-    cal_s.exit_max_threshold = exit->threshold->max;
+    cal_s.entry_roi_height = entry->roi->height; cal_s.entry_roi_width = entry->roi->width; cal_s.entry_roi_center = entry->roi->center;
+    cal_s.entry_min_threshold = entry->threshold->min; cal_s.entry_max_threshold = entry->threshold->max;
+    cal_s.exit_roi_height = exit->roi->height; cal_s.exit_roi_width = exit->roi->width; cal_s.exit_roi_center = exit->roi->center;
+    cal_s.exit_min_threshold = exit->threshold->min; cal_s.exit_max_threshold = exit->threshold->max;
     settings_prefs_.save(&cal_s);
     global_preferences->sync();
   }
@@ -173,7 +191,20 @@ void Roode::register_portal_routes_() {
     if (r->hasParam("il")) s.invalid_limit = invalid_distance_limit_ = atoi(r->getParam("il")->value().c_str());
     if (r->hasParam("rt")) s.restart_timeout = restart_timeout_ms_ = atoi(r->getParam("rt")->value().c_str());
     if (r->hasParam("m")) s.active_sensors = active_sensors_ = strtoul(r->getParam("m")->value().c_str(), NULL, 10);
-    
+
+    // ROI params (apply live and persist)
+    if (r->hasParam("erh")) { entry->roi->height = atoi(r->getParam("erh")->value().c_str()); }
+    if (r->hasParam("erw")) { entry->roi->width  = atoi(r->getParam("erw")->value().c_str()); }
+    if (r->hasParam("erc")) { entry->roi->center = atoi(r->getParam("erc")->value().c_str()); }
+    if (r->hasParam("xrh")) { exit->roi->height  = atoi(r->getParam("xrh")->value().c_str()); }
+    if (r->hasParam("xrw")) { exit->roi->width   = atoi(r->getParam("xrw")->value().c_str()); }
+    if (r->hasParam("xrc")) { exit->roi->center  = atoi(r->getParam("xrc")->value().c_str()); }
+    // Threshold params (apply live and persist)
+    if (r->hasParam("emin")) { entry->threshold->min = atoi(r->getParam("emin")->value().c_str()); }
+    if (r->hasParam("emax")) { entry->threshold->max = atoi(r->getParam("emax")->value().c_str()); }
+    if (r->hasParam("xmin")) { exit->threshold->min  = atoi(r->getParam("xmin")->value().c_str()); }
+    if (r->hasParam("xmax")) { exit->threshold->max  = atoi(r->getParam("xmax")->value().c_str()); }
+
     s.entry_roi_height = entry->roi->height; s.entry_roi_width = entry->roi->width; s.entry_roi_center = entry->roi->center;
     s.entry_min_threshold = entry->threshold->min; s.entry_max_threshold = entry->threshold->max;
     s.exit_roi_height = exit->roi->height; s.exit_roi_width = exit->roi->width; s.exit_roi_center = exit->roi->center;
@@ -201,6 +232,18 @@ void Roode::register_portal_routes_() {
   base->add_handler_without_auth(new LambdaRequestHandler(HTTP_POST, "/api/scan/cancel", [this](roode_web::AsyncWebServerRequest *r) {
     scan_state_ = SCAN_IDLE; scan_progress_ = 0;
     r->send(200, "application/json", "{\"ok\":true}");
+  }));
+  base->add_handler_without_auth(new LambdaRequestHandler(HTTP_POST, "/api/recalibrate", [this](roode_web::AsyncWebServerRequest *r) {
+    if (!require_portal_auth_(r, "application/json")) return;
+    recalibration();
+    RoodeSettings cal_s;
+    if (!settings_prefs_.load(&cal_s)) memset(&cal_s, 0, sizeof(cal_s));
+    cal_s.entry_min_threshold = entry->threshold->min; cal_s.entry_max_threshold = entry->threshold->max;
+    cal_s.exit_min_threshold  = exit->threshold->min;  cal_s.exit_max_threshold  = exit->threshold->max;
+    settings_prefs_.save(&cal_s); global_preferences->sync();
+    JsonDocument d; d["ok"] = true; d["emin"] = entry->threshold->min; d["emax"] = entry->threshold->max;
+    d["xmin"] = exit->threshold->min; d["xmax"] = exit->threshold->max; d["idle_e"] = entry->threshold->idle; d["idle_x"] = exit->threshold->idle;
+    std::string out; serializeJson(d, out); r->send(200, "application/json", out.c_str());
   }));
   base->add_handler_without_auth(new LambdaRequestHandler(HTTP_GET, "/api/scan/sessions", [this](roode_web::AsyncWebServerRequest *r) {
     if (!require_portal_auth_(r, "application/json")) return;

--- a/components/roode/roode_portal.h
+++ b/components/roode/roode_portal.h
@@ -109,14 +109,14 @@ static const char *const portal_html = R"PORTAL(
       <div class="grid">
         <div class="card">
           <h2>Roode Core</h2>
-          <div class="kv"><div class="k">Sampling</div><input type="number" id="setSampling"></div>
+          <div class="kv"><div class="k">Sampling</div><input type="number" id="setSampling" min="1" max="10"></div>
           <div class="kv"><div class="k">Orientation</div>
             <select id="setOrientation"><option value="0">Parallel</option><option value="1">Perpendicular</option></select>
           </div>
           <div class="kv"><div class="k">Invert Zones</div><label class="switch"><input type="checkbox" id="setInvert"><span class="slider"></span></label></div>
           <div class="kv"><div class="k">Persistence</div><label class="switch"><input type="checkbox" id="setPersist"><span class="slider"></span></label></div>
         </div>
-        
+
         <div class="card">
           <h2>Filtering</h2>
           <div class="kv"><div class="k">Filter Mode</div>
@@ -126,7 +126,30 @@ static const char *const portal_html = R"PORTAL(
               <option value="2">Percentile 10</option>
             </select>
           </div>
-          <div class="kv"><div class="k">Window Size</div><input type="number" id="setFilterWindow"></div>
+          <div class="kv"><div class="k">Window Size</div><input type="number" id="setFilterWindow" min="1" max="10"></div>
+        </div>
+
+        <div class="card">
+          <h2>Entry Zone ROI</h2>
+          <p style="color:var(--muted);font-size:12px">Region of Interest the sensor reads for the entry zone. Width/height 4–16, center 0–255.</p>
+          <div class="kv"><div class="k">Width (cols)</div><input type="number" id="setErw" min="4" max="16"></div>
+          <div class="kv"><div class="k">Height (rows)</div><input type="number" id="setErh" min="4" max="16"></div>
+          <div class="kv"><div class="k">Center (SPAD)</div><input type="number" id="setErc" min="0" max="255"></div>
+          <div class="kv"><div class="k">Min threshold (mm)</div><input type="number" id="setEmin" min="0"></div>
+          <div class="kv"><div class="k">Max threshold (mm)</div><input type="number" id="setEmax" min="0"></div>
+        </div>
+
+        <div class="card">
+          <h2>Exit Zone ROI</h2>
+          <p style="color:var(--muted);font-size:12px">Region of Interest the sensor reads for the exit zone.</p>
+          <div class="kv"><div class="k">Width (cols)</div><input type="number" id="setXrw" min="4" max="16"></div>
+          <div class="kv"><div class="k">Height (rows)</div><input type="number" id="setXrh" min="4" max="16"></div>
+          <div class="kv"><div class="k">Center (SPAD)</div><input type="number" id="setXrc" min="0" max="255"></div>
+          <div class="kv"><div class="k">Min threshold (mm)</div><input type="number" id="setXmin" min="0"></div>
+          <div class="kv"><div class="k">Max threshold (mm)</div><input type="number" id="setXmax" min="0"></div>
+          <div class="btns" style="margin-top:12px">
+            <button id="btnRecal" class="btn">Re-run Threshold Calibration</button>
+          </div>
         </div>
 
         <div class="card">
@@ -149,7 +172,7 @@ static const char *const portal_html = R"PORTAL(
           </div>
         </div>
       </div>
-      <div class="btns"><button id="btnSaveSettings" class="btn primary">Save & Apply Configuration</button></div>
+      <div class="btns"><button id="btnSaveSettings" class="btn primary">Save & Apply All Settings</button></div>
     </div>
 
     <!-- Sensors Tab -->
@@ -175,6 +198,9 @@ static const char *const portal_html = R"PORTAL(
           <div class="kv"><div class="k">Single Core Only</div><label class="switch"><input type="checkbox" id="setSingleCore"><span class="slider"></span></label></div>
           <div class="kv"><div class="k">Invalid Limit</div><input type="number" id="setInvalidLimit"></div>
           <div class="kv"><div class="k">Restart TO (ms)</div><input type="number" id="setRestartTO"></div>
+          <div class="btns" style="margin-top:12px">
+            <button id="btnSaveDiag" class="btn primary">Save Diagnostics</button>
+          </div>
         </div>
       </div>
     </div>
@@ -221,35 +247,43 @@ static const char *const portal_html = R"PORTAL(
         $('#luxValue').textContent = cur.lux_val + ' lx';
         $('#luxRow').style.display = 'grid';
       }
+      // Always refresh values (not just once) so portal reflects live state
+      $('#setSampling').value = cur.sa; $('#setOrientation').value = cur.or;
+      $('#setInvert').checked = cur.inv; $('#setPersist').checked = cur.cp;
+      $('#setFilterMode').value = cur.fm; $('#setFilterWindow').value = cur.fw;
+      $('#setUseLux').checked = cur.ul; $('#setUseSun').checked = cur.us;
+      $('#setSid').value = cur.sid; $('#setAddr').value = '0x'+cur.addr.toString(16);
+      $('#setTO').value = cur.to; $('#setRM').value = cur.rm;
+      $('#setDebug').checked = cur.debug; $('#setSingleCore').checked = cur.sc;
+      $('#setInvalidLimit').value = cur.il; $('#setRestartTO').value = cur.rt;
+      // Zone ROI & thresholds
+      $('#setErw').value = cur.erw; $('#setErh').value = cur.erh; $('#setErc').value = cur.erc;
+      $('#setEmin').value = cur.emin; $('#setEmax').value = cur.emax;
+      $('#setXrw').value = cur.xrw; $('#setXrh').value = cur.xrh; $('#setXrc').value = cur.xrc;
+      $('#setXmin').value = cur.xmin; $('#setXmax').value = cur.xmax;
+
       if(!window._loaded) {
-        $('#setSampling').value = cur.sa; $('#setOrientation').value = cur.or;
-        $('#setInvert').checked = cur.inv; $('#setPersist').checked = cur.cp;
-        $('#setFilterMode').value = cur.fm; $('#setFilterWindow').value = cur.fw;
-        $('#setUseLux').checked = cur.ul; $('#setUseSun').checked = cur.us;
-        $('#setSid').value = cur.sid; $('#setAddr').value = '0x'+cur.addr.toString(16);
-        $('#setTO').value = cur.to; $('#setRM').value = cur.rm;
-        $('#setDebug').checked = cur.debug; $('#setSingleCore').checked = cur.sc;
-        $('#setInvalidLimit').value = cur.il; $('#setRestartTO').value = cur.rt;
-        
         const sl = $('#sensorList'); sl.innerHTML = '';
         SENSOR_MAP.forEach(s => {
           const div = document.createElement('div'); div.className='sensor-item';
           div.innerHTML = `<span>${s.n}</span><label class="switch"><input type="checkbox" class="sensor-opt" data-id="${s.id}" ${cur.m & s.id ? 'checked' : ''}><span class="slider"></span></label>`;
           sl.append(div);
         });
-        
-        const as = $('#activeState'); as.innerHTML = '';
-        const fields = [
-          ['ROI', `${cur.erh}x${cur.erw} @ ${cur.erc} / ${cur.xrh}x${cur.xrw} @ ${cur.xrc}`],
-          ['Thresholds', `E: ${cur.emin}-${cur.emax} / X: ${cur.xmin}-${cur.xmax}`]
-        ];
-        fields.forEach(f => {
-          const d = document.createElement('div'); d.className='kv';
-          d.innerHTML = `<div class="k">${f[0]}</div><div class="v">${f[1]}</div>`;
-          as.append(d);
-        });
         window._loaded = true;
       }
+
+      const as = $('#activeState'); as.innerHTML = '';
+      const fields = [
+        ['Entry ROI', `${cur.erh}h × ${cur.erw}w @ center ${cur.erc}`],
+        ['Entry Threshold', `${cur.emin} – ${cur.emax} mm`],
+        ['Exit ROI', `${cur.xrh}h × ${cur.xrw}w @ center ${cur.xrc}`],
+        ['Exit Threshold', `${cur.xmin} – ${cur.xmax} mm`],
+      ];
+      fields.forEach(f => {
+        const d = document.createElement('div'); d.className='kv';
+        d.innerHTML = `<div class="k">${f[0]}</div><div class="v">${f[1]}</div>`;
+        as.append(d);
+      });
     }
     if(stat) {
       $('#statusText').innerHTML = `Sensor: <b>${stat.s}</b>`;
@@ -282,23 +316,51 @@ static const char *const portal_html = R"PORTAL(
   $('#btnApply').onclick = () => api('/api/roi/apply', 'POST').then(()=>alert('Applied'));
   
   function boolStr(v){ return v ? 'true' : 'false'; }
+  function intVal(id){ return parseInt(document.getElementById(id).value) || 0; }
+
   $('#btnSaveSettings').onclick = () => {
     const params = new URLSearchParams({
-      sa: parseInt($('#setSampling').value), or: parseInt($('#setOrientation').value),
+      sa: intVal('setSampling'), or: intVal('setOrientation'),
       inv: boolStr($('#setInvert').checked), cp: boolStr($('#setPersist').checked),
-      fm: parseInt($('#setFilterMode').value), fw: parseInt($('#setFilterWindow').value),
+      fm: intVal('setFilterMode'), fw: intVal('setFilterWindow'),
       ul: boolStr($('#setUseLux').checked), us: boolStr($('#setUseSun').checked),
-      sid: parseInt($('#setSid').value), to: parseInt($('#setTO').value),
-      rm: parseInt($('#setRM').value),
+      sid: intVal('setSid'), to: intVal('setTO'), rm: intVal('setRM'),
+      // Zone ROI
+      erh: intVal('setErh'), erw: intVal('setErw'), erc: intVal('setErc'),
+      emin: intVal('setEmin'), emax: intVal('setEmax'),
+      xrh: intVal('setXrh'), xrw: intVal('setXrw'), xrc: intVal('setXrc'),
+      xmin: intVal('setXmin'), xmax: intVal('setXmax'),
+      // Diagnostics
       debug: boolStr($('#setDebug').checked), sc: boolStr($('#setSingleCore').checked),
-      il: parseInt($('#setInvalidLimit').value), rt: parseInt($('#setRestartTO').value)
+      il: intVal('setInvalidLimit'), rt: intVal('setRestartTO')
     }).toString();
-    api('/api/settings/update?' + params, 'POST').then(r => r && alert('Settings Updated'));
+    api('/api/settings/update?' + params, 'POST').then(r => { if(r && r.ok) alert('Settings saved'); });
+  };
+
+  $('#btnSaveDiag').onclick = () => {
+    const params = new URLSearchParams({
+      debug: boolStr($('#setDebug').checked), sc: boolStr($('#setSingleCore').checked),
+      il: intVal('setInvalidLimit'), rt: intVal('setRestartTO')
+    }).toString();
+    api('/api/settings/update?' + params, 'POST').then(r => { if(r && r.ok) alert('Diagnostics saved'); });
+  };
+
+  $('#btnRecal').onclick = () => {
+    if(!confirm('Run threshold calibration now? Keep the sensor view clear (no people).')) return;
+    $('#btnRecal').disabled = true;
+    api('/api/recalibrate', 'POST').then(r => {
+      $('#btnRecal').disabled = false;
+      if(r && r.ok) {
+        alert(`Calibration done!\nEntry: ${r.emin}–${r.emax} mm (idle ${r.idle_e} mm)\nExit:  ${r.xmin}–${r.xmax} mm (idle ${r.idle_x} mm)`);
+      } else {
+        alert('Calibration failed — check logs.');
+      }
+    });
   };
 
   $('#btnSaveSensors').onclick = () => {
     let m = 0; document.querySelectorAll('.sensor-opt').forEach(el => { if(el.checked) m |= parseInt(el.dataset.id); });
-    api('/api/settings/update?m=' + m, 'POST').then(r => r && alert('Visibility Updated'));
+    api('/api/settings/update?m=' + m, 'POST').then(r => { if(r && r.ok) alert('Visibility updated'); });
   };
 
   setInterval(poll, 2000); poll();


### PR DESCRIPTION
The core sensor detection bug: roi starts as {0,0,0} (zero-init) and reset_roi() was never called in setup(), so every SetROI(0,0) call to the sensor hardware failed. This meant no valid readings, calibration always produced zero thresholds, and path_tracking always saw NOBODY.

- Call reset_roi() in setup() when roi is still zero, copying YAML roi_override values into the live roi before any sensor reads
- Persist ROI alongside thresholds when saving first-boot calibration
- Only load ROI from flash if the stored values are non-zero, so YAML config is correctly applied on first boot

Portal: add full ROI and threshold controls
- Entry/exit zone ROI width, height, center inputs in Config tab
- Entry/exit min/max threshold (mm) inputs with live save
- Re-run Threshold Calibration button with result alert
- Dedicated Save Diagnostics button for the system tab
- settings/update endpoint now accepts erh/erw/erc/xrh/xrw/xrc and emin/emax/xmin/xmax params and applies them live
- Add /api/recalibrate endpoint that runs calibration and returns new threshold values as JSON
- Poll always refreshes all field values (not just on first load)