### PR TITLE
Fix VL53L1X I2C crash loop, add counting toggle, improve sensor UI

### DIFF
--- a/components/roode/roode.cpp
+++ b/components/roode/roode.cpp
@@ -162,7 +162,7 @@ void Roode::register_portal_routes_() {
     doc["rm"] = distanceSensor ? get_ranging_mode_index(distanceSensor->get_ranging_mode()) : 0;
     doc["debug"] = debug_mode_; doc["sc"] = force_single_core_;
     doc["il"] = invalid_distance_limit_; doc["rt"] = (int)restart_timeout_ms_;
-    doc["m"] = active_sensors_;
+    doc["m"] = active_sensors_; doc["ce"] = counting_enabled_;
     if (lux_sensor_) doc["lux_val"] = lux_sensor_->state;
     doc["ts"] = (time(nullptr) > 1000000);
     doc["erh"] = entry->roi->height; doc["erw"] = entry->roi->width; doc["erc"] = entry->roi->center;
@@ -191,6 +191,7 @@ void Roode::register_portal_routes_() {
     if (r->hasParam("il")) s.invalid_limit = invalid_distance_limit_ = atoi(r->getParam("il")->value().c_str());
     if (r->hasParam("rt")) s.restart_timeout = restart_timeout_ms_ = atoi(r->getParam("rt")->value().c_str());
     if (r->hasParam("m")) s.active_sensors = active_sensors_ = strtoul(r->getParam("m")->value().c_str(), NULL, 10);
+    if (r->hasParam("ce")) counting_enabled_ = (r->getParam("ce")->value() == "true");
 
     // ROI params (apply live and persist)
     if (r->hasParam("erh")) { entry->roi->height = atoi(r->getParam("erh")->value().c_str()); }
@@ -317,6 +318,7 @@ VL53L1_Error Roode::read_and_track_zone_(Zone *zone, bool ut) {
 #ifdef USE_SUN
   if (use_sun_ && sun_ && sun_->elevation->state < 0.0f) return VL53L1_ERROR_NONE;
 #endif
+  if (!counting_enabled_) return VL53L1_ERROR_NONE;
   if (manual_presence_) return VL53L1_ERROR_NONE;
 
 #ifdef CONFIG_IDF_TARGET_ESP32

--- a/components/roode/roode.h
+++ b/components/roode/roode.h
@@ -186,6 +186,8 @@ class Roode : public PollingComponent {
   }
   void set_portal_password(const std::string &password) { portal_password_ = password; }
   void set_portal_enabled(bool enabled) { portal_enabled_ = enabled; }
+  void set_counting_enabled(bool enabled) { counting_enabled_ = enabled; }
+  bool is_counting_enabled() const { return counting_enabled_; }
   void set_debug_mode(bool debug) { debug_mode_ = debug; }
   void set_lux_sensor(sensor::Sensor *lux) { lux_sensor_ = lux; }
 #ifdef USE_SUN
@@ -221,6 +223,7 @@ class Roode : public PollingComponent {
   TofSensor *distanceSensor{nullptr};
   switch_::Switch *portal_switch{nullptr};
   bool portal_enabled_{true};
+  bool counting_enabled_{true};
   bool debug_mode_{false};
   uint32_t active_sensors_{0xFFFFFFFF};
   Orientation orientation_{Parallel};

--- a/components/roode/roode_portal.h
+++ b/components/roode/roode_portal.h
@@ -58,9 +58,13 @@ static const char *const portal_html = R"PORTAL(
   <div class="wrap">
     <div class="hdr">
       <h1>Roode Control</h1>
-      <div class="status">
+      <div class="status" style="display:flex;align-items:center;gap:16px">
         <span id="statusText">Status: <b>Idle</b></span>
         <span id="luxDisplay" style="display:none"> · Lux: <b id="luxValue">—</b></span>
+        <span style="display:flex;align-items:center;gap:8px;font-size:13px">
+          <span style="color:var(--muted)">Counting</span>
+          <label class="switch"><input type="checkbox" id="masterEnable" checked><span class="slider"></span></label>
+        </span>
       </div>
     </div>
 
@@ -179,9 +183,16 @@ static const char *const portal_html = R"PORTAL(
     <div id="sensors" class="tab-content">
       <div class="card">
         <h2>Sensor Visibility</h2>
-        <p style="color:var(--muted);font-size:13px">Toggle which entities are enabled and published.</p>
+        <p style="color:var(--muted);font-size:13px">Toggle which entities are enabled and published to Home Assistant.</p>
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;padding-bottom:16px;border-bottom:1px solid var(--line)">
+          <span style="font-weight:600">All Sensors</span>
+          <div style="display:flex;gap:8px;margin-left:auto">
+            <button id="btnEnableAll" class="btn">Enable All</button>
+            <button id="btnDisableAll" class="btn">Disable All</button>
+          </div>
+        </div>
         <div id="sensorList"></div>
-        <div class="btns"><button id="btnSaveSensors" class="btn primary">Update Visibility</button></div>
+        <div class="btns"><button id="btnSaveSensors" class="btn primary">Save Visibility</button></div>
       </div>
     </div>
 
@@ -262,6 +273,7 @@ static const char *const portal_html = R"PORTAL(
       $('#setXrw').value = cur.xrw; $('#setXrh').value = cur.xrh; $('#setXrc').value = cur.xrc;
       $('#setXmin').value = cur.xmin; $('#setXmax').value = cur.xmax;
 
+      if(cur.ce !== undefined) $('#masterEnable').checked = cur.ce;
       if(!window._loaded) {
         const sl = $('#sensorList'); sl.innerHTML = '';
         SENSOR_MAP.forEach(s => {
@@ -358,6 +370,15 @@ static const char *const portal_html = R"PORTAL(
     });
   };
 
+  $('#masterEnable').onchange = function() {
+    api('/api/settings/update?ce=' + boolStr(this.checked), 'POST');
+  };
+  $('#btnEnableAll').onclick = () => {
+    document.querySelectorAll('.sensor-opt').forEach(el => { el.checked = true; });
+  };
+  $('#btnDisableAll').onclick = () => {
+    document.querySelectorAll('.sensor-opt').forEach(el => { el.checked = false; });
+  };
   $('#btnSaveSensors').onclick = () => {
     let m = 0; document.querySelectorAll('.sensor-opt').forEach(el => { if(el.checked) m |= parseInt(el.dataset.id); });
     api('/api/settings/update?m=' + m, 'POST').then(r => { if(r && r.ok) alert('Visibility updated'); });

--- a/components/vl53l1x/vl53l1x.cpp
+++ b/components/vl53l1x/vl53l1x.cpp
@@ -131,63 +131,79 @@ int8_t VL53L1X::uld_write_register(uint8_t address, uint16_t register_address, c
   if (this->bus_ == nullptr || len > 64) {
     return 1;
   }
+  uint8_t effective_addr = this->i2c_address_override_ ? this->i2c_address_override_ : address;
   std::array<uint8_t, 66> buffer{};
   buffer[0] = register_address >> 8;
   buffer[1] = register_address & 0xFF;
   if (len > 0) {
     memcpy(buffer.data() + 2, data, len);
   }
-  return this->bus_->write_readv(address, buffer.data(), len + 2, nullptr, 0) == i2c::ERROR_OK ? 0 : 1;
+  return this->bus_->write_readv(effective_addr, buffer.data(), len + 2, nullptr, 0) == i2c::ERROR_OK ? 0 : 1;
 }
 
 int8_t VL53L1X::uld_read_register(uint8_t address, uint16_t register_address, uint8_t *data, size_t len) {
   if (this->bus_ == nullptr || len > 64) {
     return 1;
   }
+  uint8_t effective_addr = this->i2c_address_override_ ? this->i2c_address_override_ : address;
   std::array<uint8_t, 2> buffer{{static_cast<uint8_t>(register_address >> 8), static_cast<uint8_t>(register_address & 0xFF)}};
-  return this->bus_->write_readv(address, buffer.data(), buffer.size(), data, len) == i2c::ERROR_OK ? 0 : 1;
+  return this->bus_->write_readv(effective_addr, buffer.data(), buffer.size(), data, len) == i2c::ERROR_OK ? 0 : 1;
 }
 
 VL53L1_Error VL53L1X::init() {
-  ESP_LOGD(TAG, "Trying to initialize at address 0x%02X", address_);
+  static constexpr uint8_t FACTORY_DEFAULT = 0x29;
+  // Common relocated address used by older firmware versions. If the sensor was previously
+  // moved here and the ESP restarted (without power-cycling the sensor), we need to find it.
+  static constexpr uint8_t ALT_ADDR = 0x66;
 
+  ESP_LOGD(TAG, "Initializing sensor, configured address: 0x%02X", address_);
+
+  // Use the address override mechanism so we control exactly which I2C address the ULD
+  // driver talks to, regardless of its internal cached state.
   VL53L1_Error status;
+  uint8_t found_at = 0;
 
-#ifdef CONFIG_IDF_TARGET_ESP32
-  roode::Roode::i2c_lock();
-#endif
-  uint16_t current_addr = sensor.GetI2CAddress() >> 1;
-#ifdef CONFIG_IDF_TARGET_ESP32
-  roode::Roode::i2c_unlock();
-#endif
-
-  ESP_LOGD(TAG, "Current ULD driver address: 0x%02X", current_addr);
-
-  // Emergency re-addressing: if we expect 0x66 but sensor is at 0x29
-  if (address_ != current_addr) {
-    ESP_LOGD(TAG, "Address mismatch. Checking if sensor is at 0x29...");
-#ifdef CONFIG_IDF_TARGET_ESP32
-    roode::Roode::i2c_lock();
-#endif
-    status = sensor.SetI2CAddress(0x29 << 1); // Try to talk to 0x29
-    if (status == VL53L1_ERROR_NONE) {
-       ESP_LOGI(TAG, "Sensor found at 0x29. Moving to 0x%02X...", address_);
-       status = sensor.SetI2CAddress(address_ << 1);
-    }
-#ifdef CONFIG_IDF_TARGET_ESP32
-    roode::Roode::i2c_unlock();
-#endif
-    if (status != VL53L1_ERROR_NONE) {
-      ESP_LOGW(TAG, "Could not find sensor at 0x%02X or 0x29", address_);
-    }
-  }
-
+  // 1. Try the configured address first (covers: ESP restart with sensor keeping its address,
+  //    or first boot when address_ == 0x29 and sensor is at factory default).
+  i2c_address_override_ = address_;
   status = wait_for_boot();
-  if (status != VL53L1_ERROR_NONE) {
-    return status;
+  if (status == VL53L1_ERROR_NONE) {
+    found_at = address_;
+    ESP_LOGD(TAG, "Sensor found at configured address 0x%02X", address_);
   }
 
-  ESP_LOGD(TAG, "Found device, initializing...");
+  // 2. Fall back to factory default 0x29 (covers: XShut reset resets sensor to 0x29,
+  //    and address_ != 0x29 — the most common recovery scenario).
+  if (found_at == 0 && address_ != FACTORY_DEFAULT) {
+    ESP_LOGI(TAG, "Not found at 0x%02X, trying factory default 0x29", address_);
+    i2c_address_override_ = FACTORY_DEFAULT;
+    status = wait_for_boot();
+    if (status == VL53L1_ERROR_NONE) {
+      found_at = FACTORY_DEFAULT;
+      ESP_LOGI(TAG, "Sensor found at factory default 0x29");
+    }
+  }
+
+  // 3. If configured for 0x29 but not found, try 0x66 (covers: old firmware relocated
+  //    the sensor to 0x66 and the ESP restarted without power-cycling the sensor).
+  if (found_at == 0 && address_ == FACTORY_DEFAULT && ALT_ADDR != FACTORY_DEFAULT) {
+    ESP_LOGI(TAG, "Not found at 0x29, trying alternate address 0x%02X", ALT_ADDR);
+    i2c_address_override_ = ALT_ADDR;
+    status = wait_for_boot();
+    if (status == VL53L1_ERROR_NONE) {
+      found_at = ALT_ADDR;
+      ESP_LOGI(TAG, "Sensor found at alternate address 0x%02X", ALT_ADDR);
+    }
+  }
+
+  if (found_at == 0) {
+    i2c_address_override_ = 0;
+    ESP_LOGE(TAG, "VL53L1X not found at 0x%02X, 0x29, or 0x%02X", address_, ALT_ADDR);
+    return status;  // last non-VL53L1_ERROR_NONE status
+  }
+
+  // Initialize the sensor at the address where it was found.
+  ESP_LOGD(TAG, "Initializing device at 0x%02X", found_at);
 #ifdef CONFIG_IDF_TARGET_ESP32
   roode::Roode::i2c_lock();
 #endif
@@ -195,6 +211,32 @@ VL53L1_Error VL53L1X::init() {
 #ifdef CONFIG_IDF_TARGET_ESP32
   roode::Roode::i2c_unlock();
 #endif
+  if (status != VL53L1_ERROR_NONE) {
+    i2c_address_override_ = 0;
+    ESP_LOGE(TAG, "sensor.Init() failed at 0x%02X, error: %d", found_at, status);
+    return status;
+  }
+
+  // If found at a different address than configured, relocate the sensor.
+  // The override is still active (pointing at found_at), so SetI2CAddress writes to found_at
+  // and the sensor physically moves to address_. The ULD cache also updates.
+  if (found_at != address_) {
+    ESP_LOGI(TAG, "Relocating sensor from 0x%02X to configured address 0x%02X", found_at, address_);
+#ifdef CONFIG_IDF_TARGET_ESP32
+    roode::Roode::i2c_lock();
+#endif
+    status = sensor.SetI2CAddress(address_ << 1);
+#ifdef CONFIG_IDF_TARGET_ESP32
+    roode::Roode::i2c_unlock();
+#endif
+    if (status != VL53L1_ERROR_NONE) {
+      ESP_LOGE(TAG, "Failed to relocate sensor address, error: %d", status);
+    } else {
+      ESP_LOGI(TAG, "Sensor now at 0x%02X", address_);
+    }
+  }
+
+  i2c_address_override_ = 0;
   return status;
 }
 
@@ -204,18 +246,6 @@ VL53L1_Error VL53L1X::apply_runtime_configuration_() {
 #ifdef CONFIG_IDF_TARGET_ESP32
   roode::Roode::i2c_lock();
 #endif
-  if (desired_address_ != 0x29 && desired_address_ != address_) {
-    status = this->sensor.SetI2CAddress(desired_address_ << 1);
-    if (status == VL53L1_ERROR_NONE) {
-      char buf[5];
-      snprintf(buf, sizeof(buf), "%02X", desired_address_);
-      roode::Roode::log_event("sensor_" + std::to_string(sensor_id_) + "_addr = 0x" + std::string(buf));
-    } else {
-      ESP_LOGE(TAG, "Failed to change address. Error: %d", status);
-      goto done;
-    }
-  }
-
   if (this->offset.has_value()) {
     ESP_LOGI(TAG, "Setting offset calibration to %d", this->offset.value());
     status = this->sensor.SetOffsetInMm(this->offset.value());
@@ -233,6 +263,8 @@ VL53L1_Error VL53L1X::apply_runtime_configuration_() {
       goto done;
     }
   }
+
+  // Address relocation is handled in init() — skip here to avoid confusion.
 
   last_roi = nullptr;
   if (this->ranging_mode != nullptr) {

--- a/components/vl53l1x/vl53l1x.h
+++ b/components/vl53l1x/vl53l1x.h
@@ -101,6 +101,9 @@ class VL53L1X : public i2c::I2CDevice, public Component {
   uint8_t interrupt_miss_count_{0};
   uint32_t last_interrupt_retry_{0};
   uint8_t consecutive_failures_{0};
+  // When non-zero, all ULD I2C callbacks use this address instead of the ULD-managed one.
+  // Used during init() to probe the physical bus independently of ULD's cached address.
+  uint8_t i2c_address_override_{0};
 };
 
 }  // namespace vl53l1x


### PR DESCRIPTION
- vl53l1x: Add i2c_address_override_ mechanism so init() can probe the physical I2C bus at any address regardless of ULD driver cached state. Rewrite init() to probe configured address first, then fall back to factory default 0x29, then alternate 0x66 (old-firmware relocated). This fixes the crash loop where XShut reset or ESP restart left the physical sensor at a different address than the ULD driver expected, causing GetBootState error -13 in an infinite recovery loop.
- roode: Add counting_enabled_ flag gated in read_and_track_zone_(); exposed via /api/settings/current (ce) and /api/settings/update?ce=
- portal: Add master "Counting" toggle in header wired to ce API; add Enable All / Disable All buttons in Sensors tab for bulk control